### PR TITLE
Made syncCommands() accessable in 1.15.2

### DIFF
--- a/bukkit/latest/src/main/java/io/github/wysohn/triggerreactor/bukkit/main/TriggerReactor.java
+++ b/bukkit/latest/src/main/java/io/github/wysohn/triggerreactor/bukkit/main/TriggerReactor.java
@@ -96,7 +96,8 @@ public class TriggerReactor extends AbstractJavaPlugin {
         Server server = Bukkit.getServer();
         if (syncMethod == null) {
             try {
-                syncMethod = server.getClass().getMethod("syncCommands");
+                syncMethod = server.getClass().getDeclaredMethod("syncCommands");
+                syncMethod.setAccessible(true);
             } catch (NoSuchMethodException e) {
                 if (isDebugging())
                     e.printStackTrace();


### PR DESCRIPTION
syncCommands() is public in 1.16.2, but private in 1.15.2