### PR TITLE
Resolve #431 - new operator: try catch (finally)

### DIFF
--- a/core/src/test/java/io/github/wysohn/triggerreactor/core/script/interpreter/TestInterpreter.java
+++ b/core/src/test/java/io/github/wysohn/triggerreactor/core/script/interpreter/TestInterpreter.java
@@ -573,6 +573,39 @@ public class TestInterpreter {
     }
 
     @Test
+    public void testTry() throws Exception {
+        Charset charset = StandardCharsets.UTF_8;
+        String text = ""
+                + "TRY\n"
+                + "    start = true\n"
+                + "    error.cause()\n"
+                + "    end = true\n"
+                + "CATCH\n"
+                + "    iCatch = true\n"
+                + "FINALLY\n"
+                + "    iFinally = true\n"
+                + "ENDTRY\n";
+
+        Lexer lexer = new Lexer(text, charset);
+        Parser parser = new Parser(lexer);
+
+        Node root = parser.parse();
+        Map<String, Executor> executorMap = new HashMap<>();
+
+        Interpreter interpreter = new Interpreter(root);
+        interpreter.setExecutorMap(executorMap);
+        interpreter.setTaskSupervisor(mockTask);
+        interpreter.setSelfReference(new CommonFunctions());
+
+        interpreter.startWithContext(null);
+
+        Assert.assertTrue((boolean) interpreter.getVars().get("start"));
+        Assert.assertNull(interpreter.getVars().get("end"));
+        Assert.assertTrue((boolean) interpreter.getVars().get("iCatch"));
+        Assert.assertTrue((boolean) interpreter.getVars().get("iFinally"));
+    }
+
+    @Test
     public void testNegation() throws Exception {
         Charset charset = StandardCharsets.UTF_8;
         String text = ""


### PR DESCRIPTION
Added [try, catch, finally] statements.
If any error occurs, the error is stored in the variable **e**.

Usage: 
```
TRY
    ...
CATCH
    ...
ENDTRY
```
or
```
TRY
    ...
FINALLY
    ...
ENDTRY
```
or
```
TRY
    ...
CATCH
    ...
FINALLY
    ...
ENDTRY
```

Example
  - Usage: 
```
TRY
    #BROADCAST "try enter"

    // raise error - no exist method.
    error.raise()

    #BROADCAST "try out"
CATCH
    #BROADCAST "catch error - cause : " + e.getCause().getMessage()
FINALLY
    #BROADCAST "finally"
ENDTRY
```
  - Expected Output
```
try enter
catch error - cause : (...)
finally
```
