### PR TITLE
Fix #466 - Not CATCH bug?

### DIFF
--- a/core/src/main/java/io/github/wysohn/triggerreactor/tools/ReflectionUtil.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/tools/ReflectionUtil.java
@@ -490,7 +490,7 @@ public class ReflectionUtil {
         return classes;
     }
 
-    public static Object constructNew(Class<?> clazz, Object... args) throws NoSuchMethodException, InstantiationException, IllegalArgumentException, IllegalAccessException {
+    public static Object constructNew(Class<?> clazz, Object... args) throws NoSuchMethodException, InstantiationException, IllegalArgumentException, IllegalAccessException, InvocationTargetException {
         if (args.length < 1) {
             return clazz.newInstance();
         } else {
@@ -508,13 +508,7 @@ public class ReflectionUtil {
                 args = mergeVarargs(args, target.getParameterTypes());
             }
 
-            try {
-                return target.newInstance(args);
-            } catch (InvocationTargetException e) {
-                e.printStackTrace();
-            }
-
-            return null;
+            return target.newInstance(args);
         }
     }
 

--- a/core/src/test/java/io/github/wysohn/triggerreactor/core/script/interpreter/TestInterpreter.java
+++ b/core/src/test/java/io/github/wysohn/triggerreactor/core/script/interpreter/TestInterpreter.java
@@ -771,6 +771,42 @@ public class TestInterpreter {
     }
 
     @Test
+    public void testTryCatchInvokedMethod() throws IOException, ParserException, LexerException, InterpreterException {
+        Charset charset = StandardCharsets.UTF_8;
+        String text = "" +
+                "import java.io.FileReader;" +
+                "import java.lang.AssertionError;" +
+                "" +
+                "TRY;" +
+                "    FileReader(\"./no-exist-file.data\");" +
+                "    #VERIFY false;" +
+                "CATCH e;" +
+                "    IF e.getClass() == AssertionError;" +
+                "        #VERIFY false;" +
+                "    ENDIF;" +
+                "" +
+                "    #VERIFY true;" +
+                "ENDTRY";
+
+        Lexer lexer = new Lexer(text, charset);
+        Parser parser = new Parser(lexer);
+
+        Node root = parser.parse();
+
+        Map<String, Executor> executorMap = new HashMap<>();
+        executorMap.put("VERIFY", (timing, vars, context, args) -> {
+            Assert.assertEquals(true, args[0]);
+            return null;
+        });
+
+        Interpreter interpreter = new Interpreter(root);
+        interpreter.setExecutorMap(executorMap);
+        interpreter.setTaskSupervisor(mockTask);
+
+        interpreter.startWithContext(null);
+    }
+
+    @Test
     public void testNegation() throws Exception {
         Charset charset = StandardCharsets.UTF_8;
         String text = ""

--- a/core/src/test/java/io/github/wysohn/triggerreactor/tools/ReflectionUtilTest.java
+++ b/core/src/test/java/io/github/wysohn/triggerreactor/tools/ReflectionUtilTest.java
@@ -123,7 +123,7 @@ public class ReflectionUtilTest {
     }
 
     @Test
-    public void constructNew1() throws NoSuchMethodException, IllegalAccessException, InstantiationException {
+    public void constructNew1() throws NoSuchMethodException, IllegalAccessException, InstantiationException, InvocationTargetException {
         assertEquals(new OtherValue(), ReflectionUtil.constructNew(OtherValue.class));
 
         assertEquals(new OtherValue(1, 1), ReflectionUtil.constructNew(OtherValue.class,
@@ -140,7 +140,7 @@ public class ReflectionUtilTest {
     }
 
     @Test
-    public void constructNew2() throws NoSuchMethodException, IllegalAccessException, InstantiationException {
+    public void constructNew2() throws NoSuchMethodException, IllegalAccessException, InstantiationException, InvocationTargetException {
         //varargs in constructors
         assertEquals(new OtherValue(1, 55.55),
                 ReflectionUtil.constructNew(OtherValue.class, 1, 2.5, 3.5, 6.5, 9.9));


### PR DESCRIPTION
We can't catch invoked-method-error in the TRY-CATCH statements.
because ReflectionUtil handle the error internally, not Caller.