### PR TITLE
fix: Inconsistent key convention for each trigger managers

### DIFF
--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/Manager.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/Manager.java
@@ -28,6 +28,33 @@ import java.util.List;
  * @author wysohn
  */
 public abstract class Manager {
+    // Config keys for Common
+    public static final String SYNC = "Sync";
+
+    // Config keys for AreaTrigger
+    public static final String SMALLEST = "Smallest";
+    public static final String LARGEST = "Largest";
+
+    // Config keys for CommandTrigger
+    public static final String PERMISSIONS = "Permissions";
+    public static final String ALIASES = "Aliases";
+    public static final String TABS = "Tabs";
+
+    public static final String HINT = "Hint";
+    public static final String CANDIDATES = "Candidates";
+
+    // Config keys for CustomTrigger
+    public static final String EVENT = "Event";
+
+    // Config keys for InventoryTrigger
+    public static final String ITEMS = "Items";
+    public static final String SIZE = "Size";
+    public static final String TITLE = "Title";
+
+    // Config keys for RepeatingTrigger
+    public static final String AUTOSTART = "AutoStart";
+    public static final String INTERVAL = "Interval";
+
     private static final List<Manager> managers = new ArrayList<Manager>();
 
     public static List<Manager> getManagers() {

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/TriggerInfo.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/TriggerInfo.java
@@ -10,7 +10,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 public abstract class TriggerInfo implements IMigratable {
-    public static final String KEY_SYNC = "Sync";
+    public static final String KEY_SYNC = "sync";
     private final File sourceCodeFile;
     private final IConfigSource config;
     private final String triggerName;

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/TriggerInfo.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/TriggerInfo.java
@@ -3,6 +3,7 @@ package io.github.wysohn.triggerreactor.core.manager.trigger;
 import io.github.wysohn.triggerreactor.core.config.IMigratable;
 import io.github.wysohn.triggerreactor.core.config.IMigrationHelper;
 import io.github.wysohn.triggerreactor.core.config.source.IConfigSource;
+import io.github.wysohn.triggerreactor.core.manager.Manager;
 import io.github.wysohn.triggerreactor.tools.ValidationUtil;
 
 import java.io.File;
@@ -10,7 +11,6 @@ import java.util.Objects;
 import java.util.Optional;
 
 public abstract class TriggerInfo implements IMigratable {
-    public static final String KEY_SYNC = "sync";
     private final File sourceCodeFile;
     private final IConfigSource config;
     private final String triggerName;
@@ -68,7 +68,7 @@ public abstract class TriggerInfo implements IMigratable {
 
     public boolean isSync(){
         return Optional.ofNullable(config)
-                .flatMap(c -> c.get(KEY_SYNC))
+                .flatMap(c -> c.get(Manager.SYNC))
                 .filter(Boolean.class::isInstance)
                 .map(Boolean.class::cast)
                 .orElse(false);
@@ -77,7 +77,7 @@ public abstract class TriggerInfo implements IMigratable {
     public void setSync(boolean sync){
         ValidationUtil.notNull(config);
 
-        config.put(KEY_SYNC, sync);
+        config.put(Manager.SYNC, sync);
     }
 
     /**

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/TriggerInfo.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/TriggerInfo.java
@@ -10,7 +10,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 public abstract class TriggerInfo implements IMigratable {
-    public static final String KEY_SYNC = "sync";
+    public static final String KEY_SYNC = "Sync";
     private final File sourceCodeFile;
     private final IConfigSource config;
     private final String triggerName;

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/area/AbstractAreaTriggerManager.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/area/AbstractAreaTriggerManager.java
@@ -39,10 +39,6 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 public abstract class AbstractAreaTriggerManager extends AbstractTaggedTriggerManager<AreaTrigger> {
-    protected static final String SMALLEST = "Smallest";
-    protected static final String LARGEST = "Largest";
-    protected static final String SYNC = "Sync";
-
     protected Map<SimpleChunkLocation, Map<Area, AreaTrigger>> areaTriggersByLocation = new ConcurrentHashMap<>();
 
     /**

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/command/AbstractCommandTriggerManager.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/command/AbstractCommandTriggerManager.java
@@ -35,14 +35,6 @@ import java.util.stream.Collectors;
 
 
 public abstract class AbstractCommandTriggerManager extends AbstractTriggerManager<CommandTrigger> {
-    private static final String SYNC = "sync";
-    private static final String PERMISSION = "permissions";
-    private static final String ALIASES = "aliases";
-    public static final String TABS = "tabs";
-
-    public static final String HINT = "hint";
-    public static final String CANDIDATES = "candidates";
-
     public AbstractCommandTriggerManager(TriggerReactorCore plugin, File folder) {
         super(plugin, folder, new ITriggerLoader<CommandTrigger>() {
             private final Map<String, ITabCompleter> tabCompleterMap = new HashMap<>();
@@ -82,7 +74,7 @@ public abstract class AbstractCommandTriggerManager extends AbstractTriggerManag
 
             @Override
             public CommandTrigger load(TriggerInfo info) throws InvalidTrgConfigurationException {
-                List<String> permissions = info.getConfig().get(PERMISSION, List.class).orElse(new ArrayList<>());
+                List<String> permissions = info.getConfig().get(PERMISSIONS, List.class).orElse(new ArrayList<>());
                 List<String> aliases = info.getConfig().get(ALIASES, List.class)
                         .map(aliasList -> (((List<String>)aliasList).stream()
                                 .filter(alias -> !alias.equalsIgnoreCase(info.getTriggerName()))
@@ -108,7 +100,7 @@ public abstract class AbstractCommandTriggerManager extends AbstractTriggerManag
                 try {
                     FileUtil.writeToFile(trigger.getInfo().getSourceCodeFile(), trigger.getScript());
 
-                    trigger.getInfo().getConfig().put(PERMISSION, trigger.getPermissions());
+                    trigger.getInfo().getConfig().put(PERMISSIONS, trigger.getPermissions());
                     trigger.getInfo().getConfig().put(ALIASES, Arrays.stream(trigger.getAliases())
                             .filter(alias -> !alias.equalsIgnoreCase(trigger.getInfo().getTriggerName()))
                             .toArray());

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/custom/AbstractCustomTriggerManager.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/custom/AbstractCustomTriggerManager.java
@@ -31,8 +31,6 @@ import java.io.IOException;
 import java.util.Collection;
 
 public abstract class AbstractCustomTriggerManager extends AbstractTriggerManager<CustomTrigger> {
-    private static final String EVENT = "Event";
-
     protected final EventRegistry registry;
 
     public AbstractCustomTriggerManager(TriggerReactorCore plugin, File folder, EventRegistry registry) {

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/custom/AbstractCustomTriggerManager.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/custom/AbstractCustomTriggerManager.java
@@ -32,7 +32,6 @@ import java.util.Collection;
 
 public abstract class AbstractCustomTriggerManager extends AbstractTriggerManager<CustomTrigger> {
     private static final String EVENT = "Event";
-    private static final String SYNC = "Sync";
 
     protected final EventRegistry registry;
 
@@ -43,7 +42,7 @@ public abstract class AbstractCustomTriggerManager extends AbstractTriggerManage
                 String eventName = info.getConfig().get(EVENT, String.class)
                         .filter(registry::eventExist)
                         .orElseThrow(() -> new InvalidTrgConfigurationException("Couldn't find target Event or is not a valid Event", info.getConfig()));
-                boolean isSync = info.getConfig().get(SYNC, Boolean.class).orElse(false);
+                // boolean isSync = info.isSync();
 
                 try {
                     String script = FileUtil.readFromFile(info.getSourceCodeFile());

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/inventory/AbstractInventoryTriggerManager.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/inventory/AbstractInventoryTriggerManager.java
@@ -38,10 +38,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
 public abstract class AbstractInventoryTriggerManager<ItemStack> extends AbstractTriggerManager<InventoryTrigger> {
-    public static final String ITEMS = "Items";
-    public static final String SIZE = "Size";
-    public static final String TITLE = "Title";
-
     final static Map<IInventory, InventoryTrigger> inventoryMap = new ConcurrentHashMap<>();
     final Map<IInventory, Map<String, Object>> inventorySharedVars = new ConcurrentHashMap<>();
 

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/repeating/AbstractRepeatingTriggerManager.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/repeating/AbstractRepeatingTriggerManager.java
@@ -37,9 +37,6 @@ import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
 
 public abstract class AbstractRepeatingTriggerManager extends AbstractTriggerManager<RepeatingTrigger> {
-    private static final String AUTOSTART = "AutoStart";
-    private static final String INTERVAL = "Interval";
-
     protected static final String TRIGGER = "trigger";
 
     protected final Map<String, Thread> runningThreads = new ConcurrentHashMap<>();


### PR DESCRIPTION
As you can find in `file changed` tab, I commented out "isSync" variable so we can reuse it again as we need as in the future. Other changes are just correct to "Sync".

- Closes dareharu/TriggerReactor#3