### PR TITLE
refactor(lexer): add power to handle multi star block comments

### DIFF
--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/script/lexer/Lexer.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/script/lexer/Lexer.java
@@ -174,10 +174,11 @@ public class Lexer {
                     while (c != '*' && read()) ;
                     read();
 
+                    // Eat stream while cursor meet */, or throw exception if end of stream is reached.
                     if (c == '/') {
                         read();
                         break;
-                    } else {
+                    } else if (eos) {
                         throw new LexerException("Expected '/' but end of stream is reached", this);
                     }
                 }
@@ -488,6 +489,6 @@ public class Lexer {
         System.out.println("result: \n");
         Token tok = null;
         while ((tok = lexer.getToken()) != null)
-            System.out.println(tok.type + "] " + tok.value);
+            System.out.println("[" + tok.type + "] " + tok.value);
     }
 }

--- a/core/src/test/java/io/github/wysohn/triggerreactor/core/script/lexer/TestLexer.java
+++ b/core/src/test/java/io/github/wysohn/triggerreactor/core/script/lexer/TestLexer.java
@@ -371,6 +371,15 @@ public class TestLexer {
         testToken(lexer, Type.OPERATOR_A, "+");
         testToken(lexer, Type.INTEGER, "3");
         testEnd(lexer);
+
+        text = "4/**\n"
+            + " * heya" +
+            " */+5";
+        lexer = new Lexer(text, charset);
+        testToken(lexer, Type.INTEGER, "4");
+        testToken(lexer, Type.OPERATOR_A, "+");
+        testToken(lexer, Type.INTEGER, "5");
+        testEnd(lexer);
     }
 
     @Test


### PR DESCRIPTION
### 📑 Overview
This pull request lands ***adding power to handle multi star block comments.***

### 🧪 Examples
**Current TriggerReactor lexer**:
```
/**
 * A lot of things gone...
 */
```
throws a LexerException that messaged `Expected '/' but end of stream is reached near ...`

**TriggerReactor lexer that this feature expected**:
```
/**
 * A lot of things gone...
 */
```
just consumes the block comments.

### 🔗 Related issues
*No context*