### PR TITLE
fix: no JavaScript engine available on Spigot forks

### DIFF
--- a/bukkit/latest/build.gradle
+++ b/bukkit/latest/build.gradle
@@ -46,6 +46,7 @@ task writePluginYml {
             "ProtocolLib",
             "WorldGuard",
             "NashornJs",
+            "JShader"
     ])
     map.put("commands", new HashMap<String, Object>() {
         {

--- a/bukkit/src/main/java/io/github/wysohn/triggerreactor/bukkit/main/AbstractJavaPlugin.java
+++ b/bukkit/src/main/java/io/github/wysohn/triggerreactor/bukkit/main/AbstractJavaPlugin.java
@@ -593,11 +593,13 @@ public abstract class AbstractJavaPlugin extends JavaPlugin implements ICommandM
     }
 
     public ScriptEngineManager getScriptEngineManager() {
-        if(scriptEngineManager == null)
+        if (scriptEngineManager == null) {
             scriptEngineManager = Bukkit.getServicesManager().load(ScriptEngineManager.class);
+        }
 
-        if(scriptEngineManager == null)
-            scriptEngineManager = new ScriptEngineManager();
+        if (scriptEngineManager == null) {
+            scriptEngineManager = new ScriptEngineManager(null);
+        }
 
         return scriptEngineManager;
     }


### PR DESCRIPTION
By default with no parameters, ScriptEngineManager is automatically bound with the ClassLoader of the current thread, which may affect some conflict against Spigot forks like paper.

Pass null whilst ScriptEngineManager is constructing to fix the above-facing issue. The pull request also fixes https://github.com/TriggerReactor/TriggerReactor/issues/543 and so on fixes https://github.com/TriggerReactor/TriggerReactor/issues/530 maybe.

---
* Tracking of #544, the target branch has been changed.