### PR TITLE
Improve Give Executor

### DIFF
--- a/bukkit/src/main/resources/Executor/GIVE.js
+++ b/bukkit/src/main/resources/Executor/GIVE.js
@@ -31,7 +31,7 @@ function GIVE(args){
         var inv = player.getInventory();
         var size = 0;
         for(var i = 0; i < 36; i++){
-            if (inv.getItem(i) === null) {
+            if (inv.getItem(i) == null) {
                 size += args[0].getMaxStackSize();
             }else if (inv.getItem(i).isSimilar(args[0])){
                 size += inv.getItem(i).getMaxStackSize() - inv.getItem(i).getAmount();

--- a/bukkit/src/main/resources/Executor/GIVE.js
+++ b/bukkit/src/main/resources/Executor/GIVE.js
@@ -15,18 +15,34 @@
  *     You should have received a copy of the GNU General Public License
  *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *******************************************************************************/
+var validation = {
+    overloads: [
+        [
+            { type: ItemStack.class, name: 'itemStack' }
+        ],
+        [
+            { type: Player.class, name: 'player' },
+            { type: ItemStack.class, name: 'itemStack' }
+        ]
+    ]
+};
+
 function GIVE(args){
     if(args.length === 1){
 
-        if (!(args[0] instanceof Java.type("org.bukkit.inventory.ItemStack")))
-        {
+        if (overload === 0) {
+            target = player;
+            itemStack = args[0];
+        } else if (overload === 1) {
+            target = args[0];
+            itemStack = args[1];
+        }
+
+        if (!(args[0] instanceof Java.type("org.bukkit.inventory.ItemStack"))) {
             throw new Error("Invalid ItemStack: " + args[0]);
         }
 
-        if (!(player instanceof Java.type("org.bukkit.entity.Player")))
-        {
-            throw new Error('Player is null.');
-        }
+        if (!target) throw new Error('Player is null.');
 
         var inv = player.getInventory();
         var size = 0;

--- a/bukkit/src/main/resources/Executor/GIVE.js
+++ b/bukkit/src/main/resources/Executor/GIVE.js
@@ -16,34 +16,34 @@
  *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *******************************************************************************/
 function GIVE(args){
-	if(args.length == 1){
+    if(args.length == 1){
 
-		if (!(args[0] instanceof Java.type("org.bukkit.inventory.ItemStack")))
-		{
-			throw new Error("Invalid ItemStack: " + args[0]);
-		}
+        if (!(args[0] instanceof Java.type("org.bukkit.inventory.ItemStack")))
+        {
+            throw new Error("Invalid ItemStack: " + args[0]);
+        }
 
-		if (!(player instanceof Java.type("org.bukkit.entity.Player")))
-		{
-		    throw new Error('Player is null.');
-		}
+        if (!(player instanceof Java.type("org.bukkit.entity.Player")))
+        {
+            throw new Error('Player is null.');
+        }
 
-		var inv = player.getInventory();
-		var size = 0;
-		for(var i = 0; i < 36; i++){
-			if (inv.getItem(i) == null) {
-				size += args[0].getMaxStackSize();
-			}else if (inv.getItem(i).isSimilar(args[0])){
-				size += inv.getItem(i).getMaxStackSize() - inv.getItem(i).getAmount();
-			}
+        var inv = player.getInventory();
+        var size = 0;
+        for(var i = 0; i < 36; i++){
+            if (inv.getItem(i) === null) {
+                size += args[0].getMaxStackSize();
+            }else if (inv.getItem(i).isSimilar(args[0])){
+                size += inv.getItem(i).getMaxStackSize() - inv.getItem(i).getAmount();
+            }
 
-			if (size >= args[0].getAmount()) {
-				inv.addItem(args[0]);
-				return;
-			}
-		}
-		throw new Error("Player has no empty slot.");
-	}else{
-		throw new Error("Invalid parameters. Need [ItemStack]");
-	}
+            if (size >= args[0].getAmount()) {
+                inv.addItem(args[0]);
+                return;
+            }
+        }
+        throw new Error("Player has no empty slot.");
+    }else{
+        throw new Error("Invalid parameters. Need [ItemStack]");
+    }
 }

--- a/bukkit/src/main/resources/Executor/GIVE.js
+++ b/bukkit/src/main/resources/Executor/GIVE.js
@@ -28,38 +28,32 @@ var validation = {
 };
 
 function GIVE(args){
-    if(args.length === 1){
+    var target, itemStack;
 
-        if (overload === 0) {
-            target = player;
-            itemStack = args[0];
-        } else if (overload === 1) {
-            target = args[0];
-            itemStack = args[1];
-        }
-
-        if (!(args[0] instanceof Java.type("org.bukkit.inventory.ItemStack"))) {
-            throw new Error("Invalid ItemStack: " + args[0]);
-        }
-
-        if (!target) throw new Error('Player is null.');
-
-        var inv = player.getInventory();
-        var size = 0;
-        for(var i = 0; i < 36; i++){
-            if (inv.getItem(i) === null) {
-                size += args[0].getMaxStackSize();
-            }else if (inv.getItem(i).isSimilar(args[0])){
-                size += inv.getItem(i).getMaxStackSize() - inv.getItem(i).getAmount();
-            }
-
-            if (size >= args[0].getAmount()) {
-                inv.addItem(args[0]);
-                return;
-            }
-        }
-        throw new Error("Player has no empty slot.");
-    }else{
-        throw new Error("Invalid parameters. Need [ItemStack]");
+    if (overload === 0) {
+        target = player;
+        itemStack = args[0];
+    } else if (overload === 1) {
+        target = args[0];
+        itemStack = args[1];
     }
+
+    if (!itemStack)) throw new Error("Invalid ItemStack: " + itemStack);
+    if (!target) throw new Error('Player is null.');
+
+    var inv = player.getInventory();
+    var size = 0;
+    for(var i = 0; i < 36; i++){
+        if (inv.getItem(i) === null) {
+            size += args[0].getMaxStackSize();
+        }else if (inv.getItem(i).isSimilar(args[0])){
+            size += inv.getItem(i).getMaxStackSize() - inv.getItem(i).getAmount();
+        }
+
+        if (size >= args[0].getAmount()) {
+            inv.addItem(args[0]);
+            return;
+        }
+    }
+    throw new Error("Player has no empty slot.");
 }

--- a/bukkit/src/main/resources/Executor/GIVE.js
+++ b/bukkit/src/main/resources/Executor/GIVE.js
@@ -43,10 +43,11 @@ function GIVE(args){
 
     if (!target) throw new Error('Player is null.');
 
-    var inv = player.getInventory();
+    var inv = target.getInventory();
     var size = 0;
-    for(var i = 0; i < 36; i++){
-        if (inv.getItem(i) === null) {
+    for(var i = 0; i < inv.getSize(); i++){
+        var item = inv.getItem(i)
+        if (item === null || item.getType().isAir()) {
             size += itemStack.getMaxStackSize();
         }else if (inv.getItem(i).isSimilar(itemStack)){
             size += inv.getItem(i).getMaxStackSize() - inv.getItem(i).getAmount();

--- a/bukkit/src/main/resources/Executor/GIVE.js
+++ b/bukkit/src/main/resources/Executor/GIVE.js
@@ -15,16 +15,19 @@
  *     You should have received a copy of the GNU General Public License
  *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *******************************************************************************/
+var Player = Java.type('org.bukkit.entity.Player');
+var ItemStack = Java.type('org.bukkit.inventory.ItemStack');
+
 var validation = {
-    overloads: [
-        [
-            { type: ItemStack.class, name: 'itemStack' }
-        ],
-        [
-            { type: Player.class, name: 'player' },
-            { type: ItemStack.class, name: 'itemStack' }
-        ]
-    ]
+	overloads: [
+		[
+			{ type: ItemStack.class, name: 'itemStack' }
+		],
+		[
+			{ type: Player.class, name: 'player' },
+			{ type: ItemStack.class, name: 'itemStack' }
+		]
+	]
 };
 
 function GIVE(args){
@@ -38,7 +41,6 @@ function GIVE(args){
         itemStack = args[1];
     }
 
-    if (!itemStack)) throw new Error("Invalid ItemStack: " + itemStack);
     if (!target) throw new Error('Player is null.');
 
     var inv = player.getInventory();

--- a/bukkit/src/main/resources/Executor/GIVE.js
+++ b/bukkit/src/main/resources/Executor/GIVE.js
@@ -52,7 +52,7 @@ function GIVE(args){
             size += inv.getItem(i).getMaxStackSize() - inv.getItem(i).getAmount();
         }
 
-        if (size >= args[0].getAmount()) {
+        if (size >= itemStack.getAmount()) {
             inv.addItem(itemStack);
             return;
         }

--- a/bukkit/src/main/resources/Executor/GIVE.js
+++ b/bukkit/src/main/resources/Executor/GIVE.js
@@ -47,13 +47,13 @@ function GIVE(args){
     var size = 0;
     for(var i = 0; i < 36; i++){
         if (inv.getItem(i) === null) {
-            size += args[0].getMaxStackSize();
-        }else if (inv.getItem(i).isSimilar(args[0])){
+            size += itemStack.getMaxStackSize();
+        }else if (inv.getItem(i).isSimilar(itemStack)){
             size += inv.getItem(i).getMaxStackSize() - inv.getItem(i).getAmount();
         }
 
         if (size >= args[0].getAmount()) {
-            inv.addItem(args[0]);
+            inv.addItem(itemStack);
             return;
         }
     }

--- a/bukkit/src/main/resources/Executor/GIVE.js
+++ b/bukkit/src/main/resources/Executor/GIVE.js
@@ -15,36 +15,35 @@
  *     You should have received a copy of the GNU General Public License
  *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *******************************************************************************/
+function GIVE(args){
+	if(args.length == 1){
 
-var Player = Java.type('org.bukkit.entity.Player');
-var ItemStack = Java.type('org.bukkit.inventory.ItemStack');
+		if (!(args[0] instanceof Java.type("org.bukkit.inventory.ItemStack")))
+		{
+			throw new Error("Invalid ItemStack: " + args[0]);
+		}
 
-var validation = {
-  overloads: [
-    [
-      { type: ItemStack.class, name: 'itemStack' }
-    ],
-    [
-      { type: Player.class, name: 'player' },
-      { type: ItemStack.class, name: 'itemStack' }
-    ]
-  ]
-};
+		if (!(player instanceof Java.type("org.bukkit.entity.Player")))
+		{
+		    throw new Error('Player is null.');
+		}
 
-function GIVE(args) {
-  var target, itemStack;
+		var inv = player.getInventory();
+		var size = 0;
+		for(var i = 0; i < 36; i++){
+			if (inv.getItem(i) == null) {
+				size += args[0].getMaxStackSize();
+			}else if (inv.getItem(i).isSimilar(args[0])){
+				size += inv.getItem(i).getMaxStackSize() - inv.getItem(i).getAmount();
+			}
 
-  if (overload === 0) {
-    target = player;
-    itemStack = args[0];
-  } else if (overload === 1) {
-    target = args[0];
-    itemStack = args[1];
-  }
-
-  if (!target) throw new Error('Player is null.');
-
-  target.getInventory().addItem(itemStack);
-
-  return null;
+			if (size >= args[0].getAmount()) {
+				inv.addItem(args[0]);
+				return;
+			}
+		}
+		throw new Error("Player has no empty slot.");
+	}else{
+		throw new Error("Invalid parameters. Need [ItemStack]");
+	}
 }

--- a/bukkit/src/main/resources/Executor/GIVE.js
+++ b/bukkit/src/main/resources/Executor/GIVE.js
@@ -16,7 +16,7 @@
  *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *******************************************************************************/
 function GIVE(args){
-    if(args.length == 1){
+    if(args.length === 1){
 
         if (!(args[0] instanceof Java.type("org.bukkit.inventory.ItemStack")))
         {
@@ -31,7 +31,7 @@ function GIVE(args){
         var inv = player.getInventory();
         var size = 0;
         for(var i = 0; i < 36; i++){
-            if (inv.getItem(i) == null) {
+            if (inv.getItem(i) === null) {
                 size += args[0].getMaxStackSize();
             }else if (inv.getItem(i).isSimilar(args[0])){
                 size += inv.getItem(i).getMaxStackSize() - inv.getItem(i).getAmount();

--- a/bukkit/src/test/java/js/executor/AbstractTestExecutors.java
+++ b/bukkit/src/test/java/js/executor/AbstractTestExecutors.java
@@ -2,9 +2,8 @@ package js.executor;
 
 import io.github.wysohn.triggerreactor.bukkit.main.BukkitTriggerReactorCore;
 import io.github.wysohn.triggerreactor.core.bridge.IInventory;
-import io.github.wysohn.triggerreactor.core.bridge.entity.IPlayer;
-import io.github.wysohn.triggerreactor.core.script.validation.ValidationException;
 import io.github.wysohn.triggerreactor.core.manager.trigger.inventory.InventoryTriggerManager;
+import io.github.wysohn.triggerreactor.core.script.validation.ValidationException;
 import js.AbstractTestJavaScripts;
 import js.ExecutorTest;
 import js.JsTest;
@@ -13,7 +12,10 @@ import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.Sign;
 import org.bukkit.command.ConsoleCommandSender;
-import org.bukkit.entity.*;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.ItemFrame;
+import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.DoubleChestInventory;
 import org.bukkit.inventory.ItemStack;
@@ -399,9 +401,10 @@ public abstract class AbstractTestExecutors extends AbstractTestJavaScripts {
 
         when(player.getInventory()).thenReturn(inventory);
 
-        JsTest test = new ExecutorTest(engine, "GIVE");
+        JsTest test = new ExecutorTest(engine, "GIVE")
+                .addVariable("player", player);
 
-        test.withArgs(player, itemStack).test();
+        test.withArgs(itemStack).test();
 
         verify(inventory).addItem(itemStack);
 


### PR DESCRIPTION
# Improve Give Executor</br>
### ❓| What's different?
- The previous Give Executor used to perform addItem by detecting empty slots,
regardless of the potential inventory space the player had.

- However, in this PR, it calculates the size of the player's potential inventory space and performs addItem when Size >= Amount. Therefore, it can now accommodate codes like `#GIVE item(Material.DIAMOND, 100)`
