### PR TITLE
Support for more sophisticated numeric literals

### DIFF
--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/script/Token.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/script/Token.java
@@ -203,6 +203,29 @@ public class Token {
         }
     }
 
+    /**
+     * Base of numeric literal encoding according to its prefix.
+     */
+    public enum Base {
+        /** Literal starts with <strong><code>0b</code></strong>. */
+        Binary(2),
+
+        /** Literal starts with <strong><code>0o</code></strong>. */
+        Octal(8),
+
+        /** Literal doesn't contains a prefix. */
+        Decimal(10),
+
+        /** Literal starts with <strong><code>0x</code></strong> */
+        Hexadecimal(16);
+
+        public final int radix;
+
+        Base(final int radix) {
+            this.radix = radix;
+        }
+    }
+
     private static final Set<Class<?>> BOXED_PRIMITIVES = new HashSet<>();
     static {
         BOXED_PRIMITIVES.add(Boolean.class);

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/script/lexer/Lexer.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/script/lexer/Lexer.java
@@ -532,11 +532,11 @@ public class Lexer {
         return (StringBuilder) eatWhile(isHexadecimalDigit(), DIGIT_CONSUMER, () -> builder);
     }
 
-    private void eatNumericLiteralPostfix(final StringBuilder builder) throws IOException {
+    private void eatNumericLiteralPostfix(final StringBuilder builder) throws IOException, LexerException {
         eatNumericLiteralPostfix(builder, builder.indexOf("."));
     }
 
-    private void eatNumericLiteralPostfix(final StringBuilder builder, final boolean decSeen) throws IOException {
+    private void eatNumericLiteralPostfix(final StringBuilder builder, final boolean decSeen) throws IOException, LexerException {
         if (decSeen) {
             eatNumericLiteralPostfix(builder);
         } else {
@@ -544,11 +544,11 @@ public class Lexer {
         }
     }
 
-    private void eatNumericLiteralPostfix(final StringBuilder builder, final int decIndex) throws IOException {
+    private void eatNumericLiteralPostfix(final StringBuilder builder, final int decIndex) throws IOException, LexerException {
         eatENotation(builder, decIndex);
     }
 
-    private void eatENotation(final StringBuilder builder, final int decIndex) throws IOException {
+    private void eatENotation(final StringBuilder builder, final int decIndex) throws IOException, LexerException {
         // Look for 'e' or 'E' notation
         if (c == 'e' || c == 'E') {
             read();
@@ -558,12 +558,14 @@ public class Lexer {
                 read();  // Advance sign
 
             final CharSequence maybeExponent = eatDecimalDigits();
-            if (maybeExponent.length() == 0)
-                return;
+            if (maybeExponent.length() == 0) {
+                throw new LexerException("Exponent must be not empty.", this);
+            }
 
             final int exponent = tryParseInt(maybeExponent.toString());
-            if (exponent == 0)
-                return;
+            if (exponent == 0) {
+                throw new LexerException("Exponent must be numerical value.", this);
+            }
 
             if (decIndex == -1) {  // Int
                 if (!negative) builder.append(StringUtils.repeat("0", exponent));

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/script/lexer/Lexer.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/script/lexer/Lexer.java
@@ -494,7 +494,7 @@ public class Lexer {
         return Token.Base.Decimal;
     }
     private static final Predicate<Character> PREDICATE_DECIMAL_DIGIT = c -> Character.isDigit(c) || c == '_';
-    private static final Predicate<Character> PREDICATE_HEXADECIMAL_DIGIT = c -> Character.isLetterOrDigit(c) || c == '_';
+    private static final Predicate<Character> PREDICATE_HEXADECIMAL_DIGIT = c -> PREDICATE_DECIMAL_DIGIT.test(c) || ('a' <= c && c <= 'f') || ('A' <= c && c <= 'F');
     private static final BiConsumer<Appendable, Character> DIGIT_CONSUMER = (appendable, c) -> {
         if (c != '_') {
             try {

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/script/lexer/Lexer.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/script/lexer/Lexer.java
@@ -1,19 +1,19 @@
-/*******************************************************************************
- *     Copyright (C) 2017, 2018 wysohn
+/**
+ * Copyright (c) 2023 TriggerReactor Team
  *
- *     This program is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- *     This program is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  *
- *     You should have received a copy of the GNU General Public License
- *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *******************************************************************************/
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package io.github.wysohn.triggerreactor.core.script.lexer;
 
 import io.github.wysohn.triggerreactor.core.script.Token;

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/script/lexer/Lexer.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/script/lexer/Lexer.java
@@ -204,8 +204,6 @@ public class Lexer {
 
         if (c != '.') {
             eatNumericLiteralPostfix(builder, false);
-
-            // return new Token(Type.INTEGER, String.valueOf(tryParseInt(builder.toString(), base.radix)), row, col);
         } else {
             builder.append('.');
             read();
@@ -493,9 +491,9 @@ public class Lexer {
                 read();
                 return Token.Base.Hexadecimal;
             } else {
+                // Not a base prefix, push bask the last character
                 unread();
                 c = '0';
-                return Token.Base.Decimal;
             }
         }
 
@@ -580,7 +578,6 @@ public class Lexer {
                 builder.deleteCharAt(decIndex);
 
                 final int decimalLength = builder.length() - decIndex;
-                // final int integerLength = builder.length() - decimalLength;
                 if (!negative) {
                     // Skip if exponent == decimalLength
                     if (exponent < decimalLength) {

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/script/lexer/Lexer.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/script/lexer/Lexer.java
@@ -207,7 +207,7 @@ public class Lexer {
             builder.append('.');
             read();
             if (base != Token.Base.Decimal) {
-                throw new LexerException("Unexpected end of input.", this);
+                throw new LexerException("Float literals are unsupported base.", this);
             } else if (c == '_') {
                 throw new LexerException("Numeric separators are not allowed at the start of floating points.", this);
             } else if (!Character.isDigit(c)) {

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/script/lexer/Lexer.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/script/lexer/Lexer.java
@@ -557,7 +557,7 @@ public class Lexer {
         return identity;
     }
 
-    private static String tryParseInt(final String s, final int radix) {
+    private static int tryParseInt(final String s, final int radix) {
         int i = 0, len = s.length(), result = 0;
         final int limit = -Integer.MAX_VALUE;
         final int multmin = limit / radix;
@@ -566,17 +566,17 @@ public class Lexer {
             while (i < len) {
                 final int digit = Character.digit(s.charAt(i++), radix);
                 if (digit < 0 || result < multmin) {
-                    return "0";
+                    return 0;
                 }
                 result *= radix;
                 if (result < limit + digit) {
-                    return "0";
+                    return 0;
                 }
                 result -= digit;
             }
         }
 
-        return String.valueOf(-result);
+        return -result;
     }
 
     private static boolean isClassNameCharacter(char c) {

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/script/lexer/Lexer.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/script/lexer/Lexer.java
@@ -243,10 +243,6 @@ public class Lexer {
         return new Token(Type.DECIMAL, builder.toString(), row, col);
     }
 
-    private void eatHexadecimalDigits(final StringBuilder builder) {
-
-    }
-
     private Token readString() throws IOException, LexerException {
         StringBuilder builder = new StringBuilder();
         boolean warn = false;

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/script/lexer/Lexer.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/script/lexer/Lexer.java
@@ -570,10 +570,20 @@ public class Lexer {
             if (decIndex == -1) {  // Int
                 if (!negative) builder.append(StringUtils.repeat("0", exponent));
                 else {
-                    for (int i = 0; i < exponent; i++) {
+                    final int length = exponent - builder.length();
+                    if (length == 0) {
+                        builder.insert(0, '.');
                         builder.insert(0, '0');
+                    } else if (length > 0) {
+                        for (int i = length; i >= 0; i--) {
+                            builder.insert(0, '0');
 
-                        if (i == exponent - 2) builder.insert(0, '.');
+                            if (i == 1) {
+                                builder.insert(0, '.');
+                            }
+                        }
+                    } else {
+                        builder.insert(-length, '.');
                     }
                 }
             } else {  // Float

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/script/lexer/Lexer.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/script/lexer/Lexer.java
@@ -20,6 +20,7 @@ import io.github.wysohn.triggerreactor.core.script.Token;
 import io.github.wysohn.triggerreactor.core.script.Token.Type;
 import io.github.wysohn.triggerreactor.core.script.warning.StringInterpolationWarning;
 import io.github.wysohn.triggerreactor.core.script.warning.Warning;
+import io.github.wysohn.triggerreactor.tools.StringUtils;
 
 import java.io.*;
 import java.nio.charset.Charset;
@@ -567,7 +568,7 @@ public class Lexer {
                 return;
 
             if (decIndex == -1) {  // Int
-                if (!negative) builder.append("0".repeat(exponent));
+                if (!negative) builder.append(StringUtils.repeat("0", exponent));
                 else {
                     for (int i = 0; i < exponent; i++) {
                         builder.insert(0, '0');
@@ -585,7 +586,7 @@ public class Lexer {
                     if (exponent < decimalLength) {
                         builder.insert(decIndex + exponent, '.');
                     } else if (exponent > decimalLength) {
-                        builder.append("0".repeat(exponent - decimalLength));
+                        builder.append(StringUtils.repeat("0", exponent - decimalLength));
                     }
                 } else if (decIndex - exponent > 0) {
                     builder.insert(decIndex - exponent, '.');

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/script/lexer/Lexer.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/script/lexer/Lexer.java
@@ -475,13 +475,13 @@ public class Lexer {
         if (c == '0') {
             read();
 
-            if (c == 'b') {
+            if (c == 'b' || c == 'B') {
                 read();
                 return Token.Base.Binary;
-            } else if (c == 'o') {
+            } else if (c == 'o' || c == 'O') {
                 read();
                 return Token.Base.Octal;
-            } else if (c == 'x') {
+            } else if (c == 'x' || c == 'X') {
                 read();
                 return Token.Base.Hexadecimal;
             } else {

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/script/lexer/Lexer.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/script/lexer/Lexer.java
@@ -642,11 +642,11 @@ public class Lexer {
             while (i < len) {
                 final int digit = Character.digit(s.charAt(i++), radix);
                 if (digit < 0 || result < multmin) {
-                    return 0;
+                    throw new NumberFormatException("For input string: \"" + s + "\"");
                 }
                 result *= radix;
                 if (result < limit + digit) {
-                    return 0;
+                    throw new NumberFormatException("For input string: \"" + s + "\"");
                 }
                 result -= digit;
             }

--- a/core/src/main/java/io/github/wysohn/triggerreactor/tools/StringUtils.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/tools/StringUtils.java
@@ -1,5 +1,7 @@
 package io.github.wysohn.triggerreactor.tools;
 
+import java.util.Arrays;
+
 public class StringUtils {
     public static String spaces(int n) {
         StringBuilder builder = new StringBuilder();
@@ -35,5 +37,40 @@ public class StringUtils {
                 return true;
         }
         return false;
+    }
+
+    public static String repeat(final String s, final int count) {
+        if (count < 0) {
+            throw new IllegalArgumentException("count is negative: " + count);
+        }
+
+        if (count == 1) {
+            return s;
+        }
+
+        final int len = s.length();
+        if (len == 0 || count == 0) {
+            return "";
+        }
+
+        if (len == 1) {
+            final char[] single = new char[count];
+            Arrays.fill(single, s.charAt(0));
+            return String.valueOf(single);
+        }
+
+        if (Integer.MAX_VALUE / count < len) {
+            throw new OutOfMemoryError("Repeating " + len + " bytes String " + count +
+                                           " times will produce a String exceeding maximum size.");
+        }
+        final int limit = len * count;
+        final char[] multiple = new char[limit];
+        System.arraycopy(s, 0, multiple, 0, len);
+        int copied = len;
+        for (; copied < limit - copied; copied <<= 1) {
+            System.arraycopy(multiple, 0, multiple, copied, copied);
+        }
+        System.arraycopy(multiple, 0, multiple, copied, limit - copied);
+        return String.valueOf(multiple);
     }
 }

--- a/core/src/test/java/io/github/wysohn/triggerreactor/core/script/lexer/TestLexer.java
+++ b/core/src/test/java/io/github/wysohn/triggerreactor/core/script/lexer/TestLexer.java
@@ -432,6 +432,18 @@ public class TestLexer {
             testToken(lexer, Type.INTEGER, "12648430");
             testEnd(lexer);
         }
+        {
+            text = "0xabcdef";
+            lexer = new Lexer(text, charset);
+            testToken(lexer, Type.INTEGER, "11259375");
+            testEnd(lexer);
+        }
+        {
+            text = "0xABCDEF";
+            lexer = new Lexer(text, charset);
+            testToken(lexer, Type.INTEGER, "11259375");
+            testEnd(lexer);
+        }
     }
 
     @Test(expected = LexerException.class)
@@ -442,14 +454,14 @@ public class TestLexer {
             text = "1_000_000_000.";
             lexer = new Lexer(text, charset);
 
-            testToken(lexer, Type.INTEGER, "1000000000");
+            testToken(lexer, Type.INTEGER, "");
             testEnd(lexer);
         }
         {
             text = "0._";
             lexer = new Lexer(text, charset);
 
-            testToken(lexer, Type.DECIMAL, "0");
+            testToken(lexer, Type.DECIMAL, "");
             testEnd(lexer);
         }
     }
@@ -461,19 +473,25 @@ public class TestLexer {
         {
             text = "0b0000_0010_0000.";
             lexer = new Lexer(text, charset);
-            testToken(lexer, Type.INTEGER, "32");
+            testToken(lexer, Type.INTEGER, "");
             testEnd(lexer);
         }
         {
             text = "0o100.";
             lexer = new Lexer(text, charset);
-            testToken(lexer, Type.INTEGER, "64");
+            testToken(lexer, Type.INTEGER, "");
             testEnd(lexer);
         }
         {
             text = "0xC0FFEE.";
             lexer = new Lexer(text, charset);
-            testToken(lexer, Type.INTEGER, "12648430");
+            testToken(lexer, Type.INTEGER, "");
+            testEnd(lexer);
+        }
+        {
+            text = "0xABCDEG"; // "G" is not a part of hexadecimal
+            lexer = new Lexer(text, charset);
+            testToken(lexer, Type.INTEGER, "");
             testEnd(lexer);
         }
     }

--- a/core/src/test/java/io/github/wysohn/triggerreactor/core/script/lexer/TestLexer.java
+++ b/core/src/test/java/io/github/wysohn/triggerreactor/core/script/lexer/TestLexer.java
@@ -1,19 +1,19 @@
-/*******************************************************************************
- *     Copyright (C) 2017 wysohn
+/**
+ * Copyright (c) 2023 TriggerReactor Team
  *
- *     This program is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- *     This program is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  *
- *     You should have received a copy of the GNU General Public License
- *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *******************************************************************************/
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package io.github.wysohn.triggerreactor.core.script.lexer;
 
 import io.github.wysohn.triggerreactor.core.script.Token;

--- a/core/src/test/java/io/github/wysohn/triggerreactor/core/script/lexer/TestLexer.java
+++ b/core/src/test/java/io/github/wysohn/triggerreactor/core/script/lexer/TestLexer.java
@@ -475,6 +475,30 @@ public class TestLexer {
             testToken(lexer, Type.INTEGER, "300");
             testEnd(lexer);
         }
+        {  // Test for E notation in integer literals with minus(-) sign
+            text = "3e-2";
+            lexer = new Lexer(text, charset);
+            testToken(lexer, Type.DECIMAL, "0.03");
+            testEnd(lexer);
+        }
+        {
+            text = "123e-3";
+            lexer = new Lexer(text, charset);
+            testToken(lexer, Type.DECIMAL, "0.123");
+            testEnd(lexer);
+        }
+        {
+            text = "1234e-2";
+            lexer = new Lexer(text, charset);
+            testToken(lexer, Type.DECIMAL, "12.34");
+            testEnd(lexer);
+        }
+        {
+            text = "177e-8";
+            lexer = new Lexer(text, charset);
+            testToken(lexer, Type.DECIMAL, "0.00000177");
+            testEnd(lexer);
+        }
         {  // Test for E notation in decimal literals, which is lower-cased (Case 1)
             text = "1.23e2";
             lexer = new Lexer(text, charset);
@@ -493,13 +517,13 @@ public class TestLexer {
             testToken(lexer, Type.INTEGER, "123");
             testEnd(lexer);
         }
-        {  // Test for E notation in decimal literals with sign(+) operator (optional)
+        {  // Test for E notation in decimal literals with plus(+) sign (optional)
             text = "1.23e+2";
             lexer = new Lexer(text, charset);
             testToken(lexer, Type.INTEGER, "123");
             testEnd(lexer);
         }
-        {  // Test for E notation in decimal literals with minus(-) operator
+        {  // Test for E notation in decimal literals with minus(-) sign
             text = "1.23e-2";
             lexer = new Lexer(text, charset);
             testToken(lexer, Type.DECIMAL, "0.0123");
@@ -521,12 +545,6 @@ public class TestLexer {
             text = "177.244_325e-2";
             lexer = new Lexer(text, charset);
             testToken(lexer, Type.DECIMAL, "1.77244325");
-            testEnd(lexer);
-        }
-        {
-            text = "177e-8";
-            lexer = new Lexer(text, charset);
-            testToken(lexer, Type.DECIMAL, "0.00000177");
             testEnd(lexer);
         }
     }

--- a/core/src/test/java/io/github/wysohn/triggerreactor/core/script/lexer/TestLexer.java
+++ b/core/src/test/java/io/github/wysohn/triggerreactor/core/script/lexer/TestLexer.java
@@ -464,6 +464,67 @@ public class TestLexer {
         }
     }
 
+    @Test
+    public void testNumber_ENotation() throws Exception {
+        String text;
+        Lexer lexer;
+
+        {  // Test for E notation in integer literals
+            text = "3e2";
+            lexer = new Lexer(text, charset);
+            testToken(lexer, Type.INTEGER, "300");
+            testEnd(lexer);
+        }
+        {  // Test for E notation in decimal literals, which is lower-cased (Case 1)
+            text = "1.23e2";
+            lexer = new Lexer(text, charset);
+            testToken(lexer, Type.INTEGER, "123");
+            testEnd(lexer);
+        }
+        {  // Test for E notation in decimal literals, which is lower-cased (Case 2)
+            text = "1.23e4";
+            lexer = new Lexer(text, charset);
+            testToken(lexer, Type.INTEGER, "12300");
+            testEnd(lexer);
+        }
+        {  // Test for E notation in decimal literals, which is upper-cased
+            text = "1.23E2";
+            lexer = new Lexer(text, charset);
+            testToken(lexer, Type.INTEGER, "123");
+            testEnd(lexer);
+        }
+        {  // Test for E notation in decimal literals with sign(+) operator (optional)
+            text = "1.23e+2";
+            lexer = new Lexer(text, charset);
+            testToken(lexer, Type.INTEGER, "123");
+            testEnd(lexer);
+        }
+        {  // Test for E notation in decimal literals with minus(-) operator
+            text = "1.23e-2";
+            lexer = new Lexer(text, charset);
+            testToken(lexer, Type.DECIMAL, "0.0123");
+            testEnd(lexer);
+        }
+        {  // Test for complex literals with numeric separators(_) and also rest tests too
+            text = "1.77_244_325e8";
+            lexer = new Lexer(text, charset);
+            testToken(lexer, Type.INTEGER, "177244325");
+            testEnd(lexer);
+        }
+        {
+            text = "1.77_244_325e4";
+            lexer = new Lexer(text, charset);
+            testToken(lexer, Type.DECIMAL, "17724.4325");
+            testEnd(lexer);
+        }
+        {
+            text = "177.244_325e-2";
+            lexer = new Lexer(text, charset);
+            testToken(lexer, Type.DECIMAL, "1.77244325");
+            testEnd(lexer);
+        }
+    }
+
     @Test(expected = LexerException.class)
     public void testNumber_InvalidTokenException() throws IOException, LexerException {
         String text;

--- a/core/src/test/java/io/github/wysohn/triggerreactor/core/script/lexer/TestLexer.java
+++ b/core/src/test/java/io/github/wysohn/triggerreactor/core/script/lexer/TestLexer.java
@@ -421,13 +421,31 @@ public class TestLexer {
             testEnd(lexer);
         }
         {
+            text = "0B0000_0010_0000";  // Check for Uppercase base
+            lexer = new Lexer(text, charset);
+            testToken(lexer, Type.INTEGER, "32");
+            testEnd(lexer);
+        }
+        {
             text = "0o100";
             lexer = new Lexer(text, charset);
             testToken(lexer, Type.INTEGER, "64");
             testEnd(lexer);
         }
         {
+            text = "0O100";  // Check for Uppercase base
+            lexer = new Lexer(text, charset);
+            testToken(lexer, Type.INTEGER, "64");
+            testEnd(lexer);
+        }
+        {
             text = "0xC0FFEE";
+            lexer = new Lexer(text, charset);
+            testToken(lexer, Type.INTEGER, "12648430");
+            testEnd(lexer);
+        }
+        {
+            text = "0XC0FFEE";  // Check for Uppercase base
             lexer = new Lexer(text, charset);
             testToken(lexer, Type.INTEGER, "12648430");
             testEnd(lexer);

--- a/core/src/test/java/io/github/wysohn/triggerreactor/core/script/lexer/TestLexer.java
+++ b/core/src/test/java/io/github/wysohn/triggerreactor/core/script/lexer/TestLexer.java
@@ -581,6 +581,36 @@ public class TestLexer {
         }
     }
 
+    @Test(expected = LexerException.class)
+    public void testNumber_InvalidENotationException() throws IOException, LexerException {
+        String text;
+        Lexer lexer;
+        {
+            text = "123e";
+            lexer = new Lexer(text, charset);
+            testToken(lexer, Type.INTEGER, "");
+            testEnd(lexer);
+        }
+        {
+            text = "1.23e";
+            lexer = new Lexer(text, charset);
+            testToken(lexer, Type.INTEGER, "");
+            testEnd(lexer);
+        }
+        {
+            text = "123e-";
+            lexer = new Lexer(text, charset);
+            testToken(lexer, Type.INTEGER, "");
+            testEnd(lexer);
+        }
+        {
+            text = "1.23e-";
+            lexer = new Lexer(text, charset);
+            testToken(lexer, Type.INTEGER, "");
+            testEnd(lexer);
+        }
+    }
+
     @Test
     public void testString() throws Exception {
         String text;

--- a/core/src/test/java/io/github/wysohn/triggerreactor/core/script/lexer/TestLexer.java
+++ b/core/src/test/java/io/github/wysohn/triggerreactor/core/script/lexer/TestLexer.java
@@ -523,6 +523,12 @@ public class TestLexer {
             testToken(lexer, Type.DECIMAL, "1.77244325");
             testEnd(lexer);
         }
+        {
+            text = "177e-8";
+            lexer = new Lexer(text, charset);
+            testToken(lexer, Type.DECIMAL, "0.00000177");
+            testEnd(lexer);
+        }
     }
 
     @Test(expected = LexerException.class)


### PR DESCRIPTION
This pull request includes enhanced numeric literals things.

## Numeric separators
Using underscores as separators helps improve readability for numeric literals, both integers and decimals. This closes #556 

```java
1_000_000_000
0.000_000_001
```

## Based literals
Express in a form that specifies the base explicitly. First, we already support and can use **decimal literals (base 10)**. These are the most used as they are the numbers we use daily.

```java
x = 1
```

Secondly, we can specify integer literals in **binary form (base 2)**. These literals have to **start with 0b**.
```java
x = 0b1101
```

Thirdly, integer literals can be used in **hexadecimal form (base 16)**. They've to **start with 0x**.
```java
x = 0xC0FFEE
```

Lastly, we have the **octal form (base 8)**. In this form, they've to **start with 0o**.
```java
x = 0o100
```