### PR TITLE
Deprecate `:` operator in FOR statement, add `..` and `..=` operators instead

### DIFF
--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/script/Token.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/script/Token.java
@@ -172,6 +172,13 @@ public class Token {
          * Logical
          **/
         OPERATOR_L,
+        /**
+         * Represents `..` or `..=` operators. For example, `0..3` expression is equivalent to
+         * from 0 to 2 (exclusive; 0, 1), and `0..=2` expression is equivalent to from 0 to 3 (inclusive; 0, 1, 2).
+         *
+         * @implSpec The value must be kind of {@code <RANGE_INCLUSIVE>} or {@code <RANGE_EXCLUSIVE>}.
+         */
+        RANGE,
 
         GID, GID_TEMP, ID, PLACEHOLDER, NULLVALUE,
 

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/script/interpreter/EmptyTaskSupervisor.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/script/interpreter/EmptyTaskSupervisor.java
@@ -1,7 +1,6 @@
 package io.github.wysohn.triggerreactor.core.script.interpreter;
 
-import java.util.concurrent.Callable;
-import java.util.concurrent.Future;
+import java.util.concurrent.*;
 
 final class EmptyTaskSupervisor implements TaskSupervisor {
 
@@ -9,30 +8,67 @@ final class EmptyTaskSupervisor implements TaskSupervisor {
 
     @Override
     public <T> Future<T> submitSync(final Callable<T> callee) {
-        // TODO(Sayakie)
-        return null;
+        return new Future<T>() {
+
+            private boolean processed;
+
+            @Override
+            public boolean cancel(final boolean mayInterruptIfRunning) {
+                return false;
+            }
+
+            @Override
+            public boolean isCancelled() {
+                return false;
+            }
+
+            @Override
+            public boolean isDone() {
+                return processed;
+            }
+
+            @Override
+            public T get() throws ExecutionException {
+                final T identity;
+
+                try {
+                    identity = callee.call();
+                    processed = true;
+                } catch (final Exception e) {
+                    throw new ExecutionException(e);
+                }
+
+                return identity;
+            }
+
+            @Override
+            public T get(final long timeout, final TimeUnit unit) throws ExecutionException {
+                return get();
+            }
+        };
     }
 
     @Override
     public void submitAsync(final Runnable run) {
-        // TODO(Sayakie)
+        newThread(run, toString(), Thread.MIN_PRIORITY).start();
     }
 
     @Override
     public boolean isServerThread() {
-        // TODO(Sayakie)
         return true;
     }
 
     @Override
     public Thread newThread(final Runnable runnable, final String name, final int priority) {
-        // TODO(Sayakie)
-        return null;
+        final Thread thread = new Thread(runnable);
+        thread.setName(name);
+        thread.setPriority(priority);
+
+        return thread;
     }
 
     @Override
     public boolean equals(final Object that) {
-        // TODO(Sayakie)
         return this == that;
     }
 

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/script/interpreter/EmptyTaskSupervisor.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/script/interpreter/EmptyTaskSupervisor.java
@@ -1,0 +1,49 @@
+package io.github.wysohn.triggerreactor.core.script.interpreter;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
+
+final class EmptyTaskSupervisor implements TaskSupervisor {
+
+    static final EmptyTaskSupervisor INSTANCE = new EmptyTaskSupervisor();
+
+    @Override
+    public <T> Future<T> submitSync(final Callable<T> callee) {
+        // TODO(Sayakie)
+        return null;
+    }
+
+    @Override
+    public void submitAsync(final Runnable run) {
+        // TODO(Sayakie)
+    }
+
+    @Override
+    public boolean isServerThread() {
+        // TODO(Sayakie)
+        return true;
+    }
+
+    @Override
+    public Thread newThread(final Runnable runnable, final String name, final int priority) {
+        // TODO(Sayakie)
+        return null;
+    }
+
+    @Override
+    public boolean equals(final Object that) {
+        // TODO(Sayakie)
+        return this == that;
+    }
+
+    @Override
+    public int hashCode() {
+        return 0;
+    }
+
+    @Override
+    public String toString() {
+        return "EmptyTaskSupervisor";
+    }
+
+}

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/script/interpreter/Interpreter.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/script/interpreter/Interpreter.java
@@ -1408,6 +1408,5 @@ public class Interpreter {
     static {
         Parser.addDeprecationSupervisor(((type, value) -> type == Type.ID && "MODIFYPLAYER".equals(value)));
         Parser.addDeprecationSupervisor(((type, value) -> type == Type.ID && value.contains("$")));
-        Parser.addDeprecationSupervisor(((type, value) -> type == Type.OPERATOR && value.contains(":")));
     }
 }

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/script/interpreter/Interpreter.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/script/interpreter/Interpreter.java
@@ -360,7 +360,7 @@ public class Interpreter {
 
                 if (context.isStopFlag())
                     return;
-                Token valueToken = context.popToken();
+                Token valueToken =  context.popToken();
 
                 if (isVariable(valueToken)) {
                     valueToken = unwrapVariable(valueToken);

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/script/interpreter/Interpreter.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/script/interpreter/Interpreter.java
@@ -1408,5 +1408,6 @@ public class Interpreter {
     static {
         Parser.addDeprecationSupervisor(((type, value) -> type == Type.ID && "MODIFYPLAYER".equals(value)));
         Parser.addDeprecationSupervisor(((type, value) -> type == Type.ID && value.contains("$")));
+        Parser.addDeprecationSupervisor(((type, value) -> type == Type.OPERATOR && value.contains(":")));
     }
 }

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/script/interpreter/Interpreter.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/script/interpreter/Interpreter.java
@@ -461,11 +461,6 @@ public class Interpreter {
                 final boolean reversed = start > end;
 
                 for (int i = start;;) {
-                    if (context.isStopFlag()) {
-                        context.setStopFlag(false);
-                        break;
-                    }
-
                     if (reversed && i <= end - bound) break;
                     else if (!reversed && i >= end + bound) break;
 

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/script/lexer/Lexer.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/script/lexer/Lexer.java
@@ -141,7 +141,7 @@ public class Lexer {
             return readOperator();
         }
 
-        if (isIdCharacter(c)) {
+        if (isIdentStart(c)) {
             return readId();
         }
 
@@ -448,52 +448,47 @@ public class Lexer {
     }
 
     private Token readId() throws IOException, LexerException {
-        StringBuilder builder = new StringBuilder();
+        StringBuilder builder = new StringBuilder().append(c);
+        read();
 
-        //first character cannot be digit, etc
-        if (isIdCharacter(c)) {
-            builder.append(c);
-            read();
-        } else {
-            throw new LexerException("Cannot use " + c + " as a first character", this);
-        }
-
-        while (isIdCharacter(c) || Character.isDigit(c)) {
+        while (isIdentContinue(c)) {
             builder.append(c);
             read();
         }
 
-        String id = builder.toString();
-        if (id.equalsIgnoreCase("IMPORT")) {
-            skipWhiteSpaces();
-            skipComment();
-
-            if (c == '.') {
-                throw new LexerException("IMPORT found a dangling .(dot)", this);
-            }
-
-            if (!isClassNameCharacter(c)) {
-                throw new LexerException("IMPORT found an unexpected character [" + c + "]", this);
-            }
-
-            StringBuilder classNameBuilder = new StringBuilder();
-            while (isClassNameCharacter(c)) {
-                classNameBuilder.append(c);
-                read();
-            }
-
-            if (classNameBuilder.charAt(classNameBuilder.length() - 1) == '.')
-                classNameBuilder.deleteCharAt(classNameBuilder.length() - 1);
-
-//            skipWhiteSpaces();
-//            if (!eos && c != '\n' && c != ';') {
-//                throw new LexerException("IMPORT expected end of line or ; at the end but found [" + c + "]", this);
-//            }
-
-            return new Token(Type.IMPORT, classNameBuilder.toString(), row, col);
-        } else {
-            return new Token(Type.ID, builder.toString(), row, col);
+        final String ident = builder.toString();
+        if ("IMPORT".equalsIgnoreCase(ident)) {
+            return readImport();
+        } else if (isIdent(ident)) {
+            return new Token(Type.ID, ident, row, col);
         }
+
+        throw new LexerException("Expected identifier but found " + ident, this);
+    }
+
+    private Token readImport() throws IOException, LexerException {
+        skipWhiteSpaces();
+        skipComment();
+
+        if (c == '.') {
+            throw new LexerException("IMPORT found a dangling .(dot)", this);
+        }
+
+        if (!isClassNameCharacter(c)) {
+            throw new LexerException("IMPORT found an unexpected character [" + c + "]", this);
+        }
+
+        final StringBuilder builder = new StringBuilder();
+        while (isClassNameCharacter(c)) {
+            builder.append(c);
+            read();
+        }
+
+        if (builder.charAt(builder.length() - 1) == '.') {
+            builder.deleteCharAt(builder.length() - 1);
+        }
+
+        return new Token(Type.IMPORT, builder.toString(), row, col);
     }
 
     private Token readEndline() throws IOException {
@@ -695,8 +690,24 @@ public class Lexer {
         return Character.isDigit(c) || Character.isAlphabetic(c) || c == '.' || c == '$' || c == '_';
     }
 
+    /**
+     * @deprecated Use {@link #isIdentStart(char)} ()} instead.
+     */
+    @Deprecated(since = "3.3.7", forRemoval = true)
     private static boolean isIdCharacter(char c) {
+        return isIdentStart(c);
+    }
+
+    private static boolean isIdent(final String s) {
+        return isIdentStart(s.charAt(0)) && s.chars().skip(1).allMatch(it -> isIdentContinue((char) it));
+    }
+
+    private static boolean isIdentStart(final char c) {
         return Character.isAlphabetic(c) || c == '_' || c == '#';
+    }
+
+    private static boolean isIdentContinue(final char c) {
+        return Character.isAlphabetic(c) || Character.isDigit(c) || c == '_';
     }
 
     private static boolean isOperator(char c) {

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/script/lexer/Lexer.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/script/lexer/Lexer.java
@@ -691,9 +691,10 @@ public class Lexer {
     }
 
     /**
+     * Deprecated since 3.3.7, forRemoval.
      * @deprecated Use {@link #isIdentStart(char)} ()} instead.
      */
-    @Deprecated(since = "3.3.7", forRemoval = true)
+    @Deprecated
     private static boolean isIdCharacter(char c) {
         return isIdentStart(c);
     }

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/script/parser/Parser.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/script/parser/Parser.java
@@ -189,7 +189,12 @@ public class Parser {
                     throw new ParserException("Could not find initial value for FOR statement! " + forNode.getToken());
                 iteration.getChildren().add(first);
 
-                if (":".equals(token.value)) {
+                if (token.type == Type.RANGE || (token.type == Type.OPERATOR && ":".equals(token.value))) {
+                    final Node range = token.type == Type.RANGE
+                        ? new Node(token)
+                        : new Node(new Token(Type.RANGE, "<RANGE_EXCLUSIVE>"));  // Compatibility for `:` operator
+                    iteration.getChildren().add(range);
+
                     nextToken();
                     Node second = parseBitShift();
                     if (second == null)

--- a/core/src/test/java/io/github/wysohn/triggerreactor/core/script/interpreter/TestInterpreter.java
+++ b/core/src/test/java/io/github/wysohn/triggerreactor/core/script/interpreter/TestInterpreter.java
@@ -2235,7 +2235,7 @@ public class TestInterpreter {
     }
 
     @Test
-    public void testRangedFor_Exclusive() throws Exception {
+    public void testRangeFor_Exclusive() throws Exception {
         final String text = String.join(
             "\n",
             "FOR i = 0..2",
@@ -2264,7 +2264,7 @@ public class TestInterpreter {
     }
 
     @Test
-    public void testRangedFor_ReversedExclusive() throws Exception {
+    public void testRangeFor_ReversedExclusive() throws Exception {
         final String text = String.join(
             "\n",
             "FOR i = 3..0",
@@ -2294,7 +2294,7 @@ public class TestInterpreter {
     }
 
     @Test
-    public void testRangedFor_Inclusive() throws Exception {
+    public void testRangeFor_Inclusive() throws Exception {
         final String text = String.join(
             "\n",
             "FOR i = 0..=2",
@@ -2324,7 +2324,7 @@ public class TestInterpreter {
     }
 
     @Test
-    public void testRangedFor_ReversedInclusive() throws Exception {
+    public void testRangeFor_ReversedInclusive() throws Exception {
         final String text = String.join(
             "\n",
             "FOR i = 3..=0",

--- a/core/src/test/java/io/github/wysohn/triggerreactor/core/script/interpreter/TestInterpreter.java
+++ b/core/src/test/java/io/github/wysohn/triggerreactor/core/script/interpreter/TestInterpreter.java
@@ -52,6 +52,8 @@ import static org.mockito.Mockito.*;
 
 public class TestInterpreter {
 
+    private static final Charset charset = StandardCharsets.UTF_8;
+
     private TaskSupervisor mockTask;
 
     @Before
@@ -2230,6 +2232,126 @@ public class TestInterpreter {
         interpreter.setVars(vars);
 
         interpreter.startWithContext(null);
+    }
+
+    @Test
+    public void testRangedFor_Exclusive() throws Exception {
+        final String text = String.join(
+            "\n",
+            "FOR i = 0..2",
+            "  #TEST i",
+            "ENDFOR"
+        );
+
+        final Lexer lexer = new Lexer(text, charset);
+        final Parser parser = new Parser(lexer);
+
+        final Node root = parser.parse();
+
+        final Map<String, Executor> executors = new HashMap<>();
+        final Executor mockExecutor = mock(Executor.class);
+        when(mockExecutor.evaluate(any(), anyMap(), any(), any())).thenReturn(null);
+        executors.put("TEST", mockExecutor);
+
+        final Interpreter interpreter = new Interpreter(root);
+        interpreter.setExecutorMap(executors);
+        interpreter.setTaskSupervisor(mockTask);
+        interpreter.startWithContext(null);
+
+        InOrder inOrder = inOrder(mockExecutor);
+        inOrder.verify(mockExecutor).evaluate(any(), anyMap(), any(), eq(0));
+        inOrder.verify(mockExecutor).evaluate(any(), anyMap(), any(), eq(1));
+    }
+
+    @Test
+    public void testRangedFor_ReversedExclusive() throws Exception {
+        final String text = String.join(
+            "\n",
+            "FOR i = 3..0",
+            "  #TEST i",
+            "ENDFOR"
+        );
+
+        final Lexer lexer = new Lexer(text, charset);
+        final Parser parser = new Parser(lexer);
+
+        final Node root = parser.parse();
+
+        final Map<String, Executor> executors = new HashMap<>();
+        final Executor mockExecutor = mock(Executor.class);
+        when(mockExecutor.evaluate(any(), anyMap(), any(), any())).thenReturn(null);
+        executors.put("TEST", mockExecutor);
+
+        final Interpreter interpreter = new Interpreter(root);
+        interpreter.setExecutorMap(executors);
+        interpreter.setTaskSupervisor(mockTask);
+        interpreter.startWithContext(null);
+
+        InOrder inOrder = inOrder(mockExecutor);
+        inOrder.verify(mockExecutor).evaluate(any(), anyMap(), any(), eq(3));
+        inOrder.verify(mockExecutor).evaluate(any(), anyMap(), any(), eq(2));
+        inOrder.verify(mockExecutor).evaluate(any(), anyMap(), any(), eq(1));
+    }
+
+    @Test
+    public void testRangedFor_Inclusive() throws Exception {
+        final String text = String.join(
+            "\n",
+            "FOR i = 0..=2",
+            "  #TEST i",
+            "ENDFOR"
+        );
+
+        final Lexer lexer = new Lexer(text, charset);
+        final Parser parser = new Parser(lexer);
+
+        final Node root = parser.parse();
+
+        final Map<String, Executor> executors = new HashMap<>();
+        final Executor mockExecutor = mock(Executor.class);
+        when(mockExecutor.evaluate(any(), anyMap(), any(), any())).thenReturn(null);
+        executors.put("TEST", mockExecutor);
+
+        final Interpreter interpreter = new Interpreter(root);
+        interpreter.setExecutorMap(executors);
+        interpreter.setTaskSupervisor(mockTask);
+        interpreter.startWithContext(null);
+
+        InOrder inOrder = inOrder(mockExecutor);
+        inOrder.verify(mockExecutor).evaluate(any(), anyMap(), any(), eq(0));
+        inOrder.verify(mockExecutor).evaluate(any(), anyMap(), any(), eq(1));
+        inOrder.verify(mockExecutor).evaluate(any(), anyMap(), any(), eq(2));
+    }
+
+    @Test
+    public void testRangedFor_ReversedInclusive() throws Exception {
+        final String text = String.join(
+            "\n",
+            "FOR i = 3..=0",
+            "  #TEST i",
+            "ENDFOR"
+        );
+
+        final Lexer lexer = new Lexer(text, charset);
+        final Parser parser = new Parser(lexer);
+
+        final Node root = parser.parse();
+
+        final Map<String, Executor> executors = new HashMap<>();
+        final Executor mockExecutor = mock(Executor.class);
+        when(mockExecutor.evaluate(any(), anyMap(), any(), any())).thenReturn(null);
+        executors.put("TEST", mockExecutor);
+
+        final Interpreter interpreter = new Interpreter(root);
+        interpreter.setExecutorMap(executors);
+        interpreter.setTaskSupervisor(mockTask);
+        interpreter.startWithContext(null);
+
+        InOrder inOrder = inOrder(mockExecutor);
+        inOrder.verify(mockExecutor).evaluate(any(), anyMap(), any(), eq(3));
+        inOrder.verify(mockExecutor).evaluate(any(), anyMap(), any(), eq(2));
+        inOrder.verify(mockExecutor).evaluate(any(), anyMap(), any(), eq(1));
+        inOrder.verify(mockExecutor).evaluate(any(), anyMap(), any(), eq(0));
     }
 
     @Test

--- a/core/src/test/java/io/github/wysohn/triggerreactor/core/script/lexer/TestLexer.java
+++ b/core/src/test/java/io/github/wysohn/triggerreactor/core/script/lexer/TestLexer.java
@@ -826,6 +826,29 @@ public class TestLexer {
     }
 
     @Test
+    public void testRange() throws Exception {
+        String text;
+        Lexer lexer;
+
+        {
+            text = "0..3";
+            lexer = new Lexer(text, charset);
+            testToken(lexer, Type.INTEGER, "0");
+            testToken(lexer, Type.RANGE, "<RANGE_EXCLUSIVE>");
+            testToken(lexer, Type.INTEGER, "3");
+            testEnd(lexer);
+        }
+        {
+            text = "0..=3";
+            lexer = new Lexer(text, charset);
+            testToken(lexer, Type.INTEGER, "0");
+            testToken(lexer, Type.RANGE, "<RANGE_INCLUSIVE>");
+            testToken(lexer, Type.INTEGER, "3");
+            testEnd(lexer);
+        }
+    }
+
+    @Test
     public void testId() throws Exception {
 
     }

--- a/core/src/test/java/io/github/wysohn/triggerreactor/core/script/parser/TestParser.java
+++ b/core/src/test/java/io/github/wysohn/triggerreactor/core/script/parser/TestParser.java
@@ -30,7 +30,6 @@ import java.util.LinkedList;
 import java.util.Queue;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 public class TestParser {
 
@@ -38,6 +37,7 @@ public class TestParser {
 
     @Test
     public void testParse() throws IOException, LexerException, ParserException {
+        Charset charset = Charset.forName("UTF-8");
         String text = "#MESSAGE (1+(4/2.0)/3*4-(2/(3*-4)) >= 0)\n"
                 + "#MESSAGE \"text\"\n";
 
@@ -76,6 +76,7 @@ public class TestParser {
 
     @Test
     public void testBitwiseAndBitshift() throws Exception {
+        Charset charset = Charset.forName("UTF-8");
         String text = "#MESSAGE (1>>2/1%-~5|~2+1<<3^4) <= 3 | (3<<4&2) > 1 & (6>>>~-2) > 2 ^ (1|~(3+2<<1*2)) > 3\n";
 
         Lexer lexer = new Lexer(text, charset);
@@ -142,6 +143,7 @@ public class TestParser {
 
     @Test
     public void testIncrementAndDecrement() throws Exception {
+        Charset charset = Charset.forName("UTF-8");
         String text = "a = 2\n" +
                 "a = ++a * --a - a++ / a--\n" +
                 "a = -(--a) -(++a) -(a++) -(a--)\n" +
@@ -243,6 +245,7 @@ public class TestParser {
 
     @Test
     public void testParam() throws IOException, LexerException, ParserException {
+        Charset charset = Charset.forName("UTF-8");
         String text = "#SOUND player.getLocation() \"LEVEL_UP\" 1.0 1.0";
 
         Lexer lexer = new Lexer(text, charset);
@@ -268,8 +271,7 @@ public class TestParser {
 
     @Test
     public void testFor() throws Exception {
-        Parser.addDeprecationSupervisor((type, value) -> type == Type.OPERATOR && ":".equals(value));
-
+        Charset charset = Charset.forName("UTF-8");
         String text = ""
                 + "FOR i = 0:10;"
                 + "    #MESSAGE \"test i=\"+i;"
@@ -333,7 +335,7 @@ public class TestParser {
         assertEquals(new Node(new Token(Type.BODY, "<BODY>")), queue.poll());
         assertEquals(new Node(new Token(Type.ID, "FOR")), queue.poll());
         assertEquals(new Node(new Token(Type.ROOT, "<ROOT>")), queue.poll());
-        assertTrue(queue.isEmpty());
+        assertEquals(0, queue.size());
     }
 
     @Test
@@ -367,11 +369,12 @@ public class TestParser {
         assertEquals(new Node(new Token(Type.BODY, "<BODY>")), queue.poll());
         assertEquals(new Node(new Token(Type.ID, "FOR")), queue.poll());
         assertEquals(new Node(new Token(Type.ROOT, "<ROOT>")), queue.poll());
-        assertTrue(queue.isEmpty());
+        assertEquals(0, queue.size());
     }
 
     @Test
     public void testNegation() throws Exception {
+        Charset charset = Charset.forName("UTF-8");
         String text = ""
                 + "IF !(true && false && true || 2 < 1 && 1 < 2)\n"
                 + "    #MESSAGE \"test i=\"+i\n"
@@ -413,6 +416,7 @@ public class TestParser {
 
     @Test
     public void testPlaceholder() throws Exception {
+        Charset charset = Charset.forName("UTF-8");
         String text = ""
                 + "x = 10;"
                 + "#MESSAGE $placeholdertest@main:0:x:5:true;";
@@ -444,6 +448,7 @@ public class TestParser {
 
     @Test
     public void testIf() throws Exception {
+        Charset charset = Charset.forName("UTF-8");
         String text = ""
                 + "IF i == 0;"
                 + "    #MESSAGE 0;"
@@ -509,6 +514,7 @@ public class TestParser {
         Parser.addDeprecationSupervisor((type, value) ->
                 type == Type.ID && "#MODIFYPLAYER".equals(value));
 
+        Charset charset = Charset.forName("UTF-8");
         String text = "#MESSAGE (1+(4/2.0)/3*4-(2/(3*-4)) >= 0)\n"
                 + "#MODIFYPLAYER \"text\"\n";
 
@@ -551,6 +557,7 @@ public class TestParser {
 
     @Test
     public void testLiteralStringTrueOrFalse() throws Exception {
+        Charset charset = StandardCharsets.UTF_8;
         String text = ""
             + "temp1 = \"true\";"
             + "temp2 = true;";
@@ -569,11 +576,11 @@ public class TestParser {
         assertEquals(new Node(new Token(Type.STRING, "true")), queue.poll());
         assertEquals(new Node(new Token(Type.OPERATOR, "=")), queue.poll());
 
-        assertEquals(new Node(new Token(Type.THIS, "<This>")), queue.poll());
-        assertEquals(new Node(new Token(Type.ID, "temp2")), queue.poll());
-        assertEquals(new Node(new Token(Type.OPERATOR, ".")), queue.poll());
-        assertEquals(new Node(new Token(Type.BOOLEAN, "true")), queue.poll());
-        assertEquals(new Node(new Token(Type.OPERATOR, "=")), queue.poll());
+      assertEquals(new Node(new Token(Type.THIS, "<This>")), queue.poll());
+      assertEquals(new Node(new Token(Type.ID, "temp2")), queue.poll());
+      assertEquals(new Node(new Token(Type.OPERATOR, ".")), queue.poll());
+      assertEquals(new Node(new Token(Type.BOOLEAN, "true")), queue.poll());
+      assertEquals(new Node(new Token(Type.OPERATOR, "=")), queue.poll());
 
         assertEquals(new Node(new Token(Type.ROOT, "<ROOT>")), queue.poll());
         assertEquals(0, queue.size());

--- a/core/src/test/java/io/github/wysohn/triggerreactor/core/script/parser/TestParser.java
+++ b/core/src/test/java/io/github/wysohn/triggerreactor/core/script/parser/TestParser.java
@@ -287,6 +287,7 @@ public class TestParser {
         assertEquals(new Node(new Token(Type.ID, "i")), queue.poll());
         assertEquals(new Node(new Token(Type.OPERATOR, ".")), queue.poll());
         assertEquals(new Node(new Token(Type.INTEGER, "0")), queue.poll());
+        assertEquals(new Node(new Token(Type.RANGE, "<RANGE_EXCLUSIVE>")), queue.poll());
         assertEquals(new Node(new Token(Type.INTEGER, "10")), queue.poll());
         assertEquals(new Node(new Token(Type.ITERATOR, "<ITERATOR>")), queue.poll());
         assertEquals(new Node(new Token(Type.STRING, "test i=")), queue.poll());

--- a/core/src/test/java/io/github/wysohn/triggerreactor/core/script/parser/TestParser.java
+++ b/core/src/test/java/io/github/wysohn/triggerreactor/core/script/parser/TestParser.java
@@ -33,6 +33,8 @@ import static org.junit.Assert.assertEquals;
 
 public class TestParser {
 
+    private static final Charset charset = StandardCharsets.UTF_8;
+
     @Test
     public void testParse() throws IOException, LexerException, ParserException {
         Charset charset = Charset.forName("UTF-8");
@@ -296,6 +298,74 @@ public class TestParser {
         assertEquals(new Node(new Token(Type.OPERATOR, ".")), queue.poll());
         assertEquals(new Node(new Token(Type.OPERATOR_A, "+")), queue.poll());
         assertEquals(new Node(new Token(Type.EXECUTOR, "MESSAGE")), queue.poll());
+        assertEquals(new Node(new Token(Type.BODY, "<BODY>")), queue.poll());
+        assertEquals(new Node(new Token(Type.ID, "FOR")), queue.poll());
+        assertEquals(new Node(new Token(Type.ROOT, "<ROOT>")), queue.poll());
+        assertEquals(0, queue.size());
+    }
+
+    @Test
+    public void testRangeFor_Inclusive() throws Exception {
+        String text = String.join(
+            "\n",
+            "FOR i = 0..=3",
+            "  #TEST i",
+            "ENDFOR"
+        );
+
+        Lexer lexer = new Lexer(text, charset);
+        Parser parser = new Parser(lexer);
+
+        Node root = parser.parse();
+        Queue<Node> queue = new LinkedList<Node>();
+
+        serializeNode(queue, root);
+
+        assertEquals(new Node(new Token(Type.THIS, "<This>")), queue.poll());
+        assertEquals(new Node(new Token(Type.ID, "i")), queue.poll());
+        assertEquals(new Node(new Token(Type.OPERATOR, ".")), queue.poll());
+        assertEquals(new Node(new Token(Type.INTEGER, "0")), queue.poll());
+        assertEquals(new Node(new Token(Type.RANGE, "<RANGE_INCLUSIVE>")), queue.poll());
+        assertEquals(new Node(new Token(Type.INTEGER, "3")), queue.poll());
+        assertEquals(new Node(new Token(Type.ITERATOR, "<ITERATOR>")), queue.poll());
+        assertEquals(new Node(new Token(Type.THIS, "<This>")), queue.poll());
+        assertEquals(new Node(new Token(Type.ID, "i")), queue.poll());
+        assertEquals(new Node(new Token(Type.OPERATOR, ".")), queue.poll());
+        assertEquals(new Node(new Token(Type.EXECUTOR, "TEST")), queue.poll());
+        assertEquals(new Node(new Token(Type.BODY, "<BODY>")), queue.poll());
+        assertEquals(new Node(new Token(Type.ID, "FOR")), queue.poll());
+        assertEquals(new Node(new Token(Type.ROOT, "<ROOT>")), queue.poll());
+        assertEquals(0, queue.size());
+    }
+
+    @Test
+    public void testRangeFor_Exclusive() throws Exception {
+        String text = String.join(
+            "\n",
+            "FOR i = 0..3",
+            "  #TEST i",
+            "ENDFOR"
+        );
+
+        Lexer lexer = new Lexer(text, charset);
+        Parser parser = new Parser(lexer);
+
+        Node root = parser.parse();
+        Queue<Node> queue = new LinkedList<Node>();
+
+        serializeNode(queue, root);
+
+        assertEquals(new Node(new Token(Type.THIS, "<This>")), queue.poll());
+        assertEquals(new Node(new Token(Type.ID, "i")), queue.poll());
+        assertEquals(new Node(new Token(Type.OPERATOR, ".")), queue.poll());
+        assertEquals(new Node(new Token(Type.INTEGER, "0")), queue.poll());
+        assertEquals(new Node(new Token(Type.RANGE, "<RANGE_EXCLUSIVE>")), queue.poll());
+        assertEquals(new Node(new Token(Type.INTEGER, "3")), queue.poll());
+        assertEquals(new Node(new Token(Type.ITERATOR, "<ITERATOR>")), queue.poll());
+        assertEquals(new Node(new Token(Type.THIS, "<This>")), queue.poll());
+        assertEquals(new Node(new Token(Type.ID, "i")), queue.poll());
+        assertEquals(new Node(new Token(Type.OPERATOR, ".")), queue.poll());
+        assertEquals(new Node(new Token(Type.EXECUTOR, "TEST")), queue.poll());
         assertEquals(new Node(new Token(Type.BODY, "<BODY>")), queue.poll());
         assertEquals(new Node(new Token(Type.ID, "FOR")), queue.poll());
         assertEquals(new Node(new Token(Type.ROOT, "<ROOT>")), queue.poll());

--- a/core/src/test/java/io/github/wysohn/triggerreactor/core/script/parser/TestParser.java
+++ b/core/src/test/java/io/github/wysohn/triggerreactor/core/script/parser/TestParser.java
@@ -30,6 +30,7 @@ import java.util.LinkedList;
 import java.util.Queue;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class TestParser {
 
@@ -37,7 +38,6 @@ public class TestParser {
 
     @Test
     public void testParse() throws IOException, LexerException, ParserException {
-        Charset charset = Charset.forName("UTF-8");
         String text = "#MESSAGE (1+(4/2.0)/3*4-(2/(3*-4)) >= 0)\n"
                 + "#MESSAGE \"text\"\n";
 
@@ -76,7 +76,6 @@ public class TestParser {
 
     @Test
     public void testBitwiseAndBitshift() throws Exception {
-        Charset charset = Charset.forName("UTF-8");
         String text = "#MESSAGE (1>>2/1%-~5|~2+1<<3^4) <= 3 | (3<<4&2) > 1 & (6>>>~-2) > 2 ^ (1|~(3+2<<1*2)) > 3\n";
 
         Lexer lexer = new Lexer(text, charset);
@@ -143,7 +142,6 @@ public class TestParser {
 
     @Test
     public void testIncrementAndDecrement() throws Exception {
-        Charset charset = Charset.forName("UTF-8");
         String text = "a = 2\n" +
                 "a = ++a * --a - a++ / a--\n" +
                 "a = -(--a) -(++a) -(a++) -(a--)\n" +
@@ -245,7 +243,6 @@ public class TestParser {
 
     @Test
     public void testParam() throws IOException, LexerException, ParserException {
-        Charset charset = Charset.forName("UTF-8");
         String text = "#SOUND player.getLocation() \"LEVEL_UP\" 1.0 1.0";
 
         Lexer lexer = new Lexer(text, charset);
@@ -271,7 +268,8 @@ public class TestParser {
 
     @Test
     public void testFor() throws Exception {
-        Charset charset = Charset.forName("UTF-8");
+        Parser.addDeprecationSupervisor((type, value) -> type == Type.OPERATOR && ":".equals(value));
+
         String text = ""
                 + "FOR i = 0:10;"
                 + "    #MESSAGE \"test i=\"+i;"
@@ -335,7 +333,7 @@ public class TestParser {
         assertEquals(new Node(new Token(Type.BODY, "<BODY>")), queue.poll());
         assertEquals(new Node(new Token(Type.ID, "FOR")), queue.poll());
         assertEquals(new Node(new Token(Type.ROOT, "<ROOT>")), queue.poll());
-        assertEquals(0, queue.size());
+        assertTrue(queue.isEmpty());
     }
 
     @Test
@@ -369,12 +367,11 @@ public class TestParser {
         assertEquals(new Node(new Token(Type.BODY, "<BODY>")), queue.poll());
         assertEquals(new Node(new Token(Type.ID, "FOR")), queue.poll());
         assertEquals(new Node(new Token(Type.ROOT, "<ROOT>")), queue.poll());
-        assertEquals(0, queue.size());
+        assertTrue(queue.isEmpty());
     }
 
     @Test
     public void testNegation() throws Exception {
-        Charset charset = Charset.forName("UTF-8");
         String text = ""
                 + "IF !(true && false && true || 2 < 1 && 1 < 2)\n"
                 + "    #MESSAGE \"test i=\"+i\n"
@@ -416,7 +413,6 @@ public class TestParser {
 
     @Test
     public void testPlaceholder() throws Exception {
-        Charset charset = Charset.forName("UTF-8");
         String text = ""
                 + "x = 10;"
                 + "#MESSAGE $placeholdertest@main:0:x:5:true;";
@@ -448,7 +444,6 @@ public class TestParser {
 
     @Test
     public void testIf() throws Exception {
-        Charset charset = Charset.forName("UTF-8");
         String text = ""
                 + "IF i == 0;"
                 + "    #MESSAGE 0;"
@@ -514,7 +509,6 @@ public class TestParser {
         Parser.addDeprecationSupervisor((type, value) ->
                 type == Type.ID && "#MODIFYPLAYER".equals(value));
 
-        Charset charset = Charset.forName("UTF-8");
         String text = "#MESSAGE (1+(4/2.0)/3*4-(2/(3*-4)) >= 0)\n"
                 + "#MODIFYPLAYER \"text\"\n";
 
@@ -557,7 +551,6 @@ public class TestParser {
 
     @Test
     public void testLiteralStringTrueOrFalse() throws Exception {
-        Charset charset = StandardCharsets.UTF_8;
         String text = ""
             + "temp1 = \"true\";"
             + "temp2 = true;";
@@ -576,11 +569,11 @@ public class TestParser {
         assertEquals(new Node(new Token(Type.STRING, "true")), queue.poll());
         assertEquals(new Node(new Token(Type.OPERATOR, "=")), queue.poll());
 
-      assertEquals(new Node(new Token(Type.THIS, "<This>")), queue.poll());
-      assertEquals(new Node(new Token(Type.ID, "temp2")), queue.poll());
-      assertEquals(new Node(new Token(Type.OPERATOR, ".")), queue.poll());
-      assertEquals(new Node(new Token(Type.BOOLEAN, "true")), queue.poll());
-      assertEquals(new Node(new Token(Type.OPERATOR, "=")), queue.poll());
+        assertEquals(new Node(new Token(Type.THIS, "<This>")), queue.poll());
+        assertEquals(new Node(new Token(Type.ID, "temp2")), queue.poll());
+        assertEquals(new Node(new Token(Type.OPERATOR, ".")), queue.poll());
+        assertEquals(new Node(new Token(Type.BOOLEAN, "true")), queue.poll());
+        assertEquals(new Node(new Token(Type.OPERATOR, "=")), queue.poll());
 
         assertEquals(new Node(new Token(Type.ROOT, "<ROOT>")), queue.poll());
         assertEquals(0, queue.size());


### PR DESCRIPTION
## 🌟 Features

* Introduce new `RANGE` token type
* Add new `..` and `..=` range operators
* Support backward iteration
* Mark `:` operator as deprecated symbol

## 🚩 Syntax

```java
[0-9]..[0-9]  (End should be exclusive)
[0-9]..=[0-9] (End should be inclusive)
```

## 📜 Examples

```java
FOR i = 3..0
  #MESSAGE i
ENDFOR

/// Prints
/// >> "3"
/// >> "2"
/// >> "1"
```

```java
FOR i = 8..=10
  #MESSAGE i
ENDFOR

/// Prints
/// >> "8"
/// >> "9"
/// >> "10"
```

## 🧷 Tracking issues

- [x] #562 
- [x] #250