### PR TITLE
Support hex color

### DIFF
--- a/bukkit/src/main/resources/Executor/BROADCAST.js
+++ b/bukkit/src/main/resources/Executor/BROADCAST.js
@@ -1,6 +1,5 @@
 /*******************************************************************************
- *     Copyright (C) 2017 wysohn
- *     Copyright (C) 2022 Ioloolo
+ *     Copyright (c) 2023 TriggerReactor Team
  *
  *     This program is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU General Public License as published by

--- a/bukkit/src/main/resources/Executor/BROADCAST.js
+++ b/bukkit/src/main/resources/Executor/BROADCAST.js
@@ -16,12 +16,12 @@
  *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *******************************************************************************/
 
-var Object = Java.type('java.lang.Object');
-
+var Dependency = Java.type('io.github.wysohn.triggerreactor.core.main.Dependency');
+var Platform = Java.type('io.github.wysohn.triggerreactor.core.main.Platform');
+var BukkitUtil = Java.type('io.github.wysohn.triggerreactor.bukkit.tools.BukkitUtil');
 var Bukkit = Java.type('org.bukkit.Bukkit');
 var ChatColor = Java.type('org.bukkit.ChatColor');
-
-var BukkitUtil = Java.type('io.github.wysohn.triggerreactor.bukkit.tools.BukkitUtil');
+var Object = Java.type('java.lang.Object');
 
 var validation = {
   overloads: [
@@ -35,10 +35,17 @@ function BROADCAST(args) {
   var PlaceholderAPI;
   var message = args[0].toString()
 
-  if (Bukkit.getPluginManager().isPluginEnabled('PlaceholderAPI'))
-    PlaceholderAPI = Java.type('me.clip.placeholderapi.PlaceholderAPI');
-
   message = ChatColor.translateAlternateColorCodes('&', message);
+
+  if (Bukkit.getPluginManager().isPluginEnabled('PlaceholderAPI')) {}
+    PlaceholderAPI = Java.type('me.clip.placeholderapi.PlaceholderAPI');
+  }
+
+  var platform = plugin.getPlatform();
+  if (platform.supports(Dependency.MiniMessage)) {
+    var mm = Java.type('net.kyori.adventure.text.minimessage.MiniMessage').miniMessage();
+    message = mm.deserialize(message);
+  }
 
   var players = BukkitUtil.getOnlinePlayers();
   var iter = players.iterator();

--- a/bukkit/src/main/resources/Executor/LOG.js
+++ b/bukkit/src/main/resources/Executor/LOG.js
@@ -1,6 +1,5 @@
 /*******************************************************************************
- *     Copyright (C) 2017 wysohn
- *     Copyright (C) 2022 Ioloolo
+ *     Copyright (c) 2023 TriggerReactor Team
  *
  *     This program is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU General Public License as published by

--- a/bukkit/src/main/resources/Executor/LOG.js
+++ b/bukkit/src/main/resources/Executor/LOG.js
@@ -16,7 +16,10 @@
  *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *******************************************************************************/
 
+var Dependency = Java.type('io.github.wysohn.triggerreactor.core.main.Dependency');
+var Platform = Java.type('io.github.wysohn.triggerreactor.core.main.Platform');
 var Bukkit = Java.type('org.bukkit.Bukkit');
+var ChatColor = Java.type('org.bukkit.ChatColor');
 var Object = Java.type('java.lang.Object');
 
 var validation = {
@@ -29,6 +32,13 @@ var validation = {
 
 function LOG(args) {
   var message = args[0].toString();
+  message = ChatColor.translateAlternateColorCodes('&', message);
+
+  var platform = plugin.getPlatform();
+  if (platform.supports(Dependency.MiniMessage)) {
+    var mm = Java.type('net.kyori.adventure.text.minimessage.MiniMessage').miniMessage();
+    message = mm.deserialize(message);
+  }
 
   Bukkit.getConsoleSender().sendMessage(message);
 

--- a/bukkit/src/main/resources/Executor/MESSAGE.js
+++ b/bukkit/src/main/resources/Executor/MESSAGE.js
@@ -1,6 +1,5 @@
 /*******************************************************************************
- *     Copyright (C) 2017 wysohn
- *     Copyright (C) 2022 Ioloolo
+ *     Copyright (c) 2023 TriggerReactor Team
  *
  *     This program is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU General Public License as published by

--- a/bukkit/src/main/resources/Executor/MESSAGE.js
+++ b/bukkit/src/main/resources/Executor/MESSAGE.js
@@ -16,6 +16,9 @@
  *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *******************************************************************************/
 
+var TriggerReactorCore = Java.type('io.github.wysohn.triggerreactor.core.main.TriggerReactorCore');
+var Dependency = Java.type('io.github.wysohn.triggerreactor.core.main.Dependency');
+var Platform = Java.type('io.github.wysohn.triggerreactor.core.main.Platform');
 var Bukkit = Java.type('org.bukkit.Bukkit');
 var ChatColor = Java.type('org.bukkit.ChatColor');
 var Object = Java.type('java.lang.Object');
@@ -29,7 +32,9 @@ var validation = {
 };
 
 function MESSAGE(args) {
-  if (!player) throw new Error('Player is null.');
+  if (!player) {
+    throw new Error('Player is null.');
+  }
 
   var message = args[0].toString()
 
@@ -38,6 +43,12 @@ function MESSAGE(args) {
   if (Bukkit.getPluginManager().isPluginEnabled('PlaceholderAPI')) {
     var PlaceholderAPI = Java.type('me.clip.placeholderapi.PlaceholderAPI');
     message = PlaceholderAPI.setPlaceholders(player, message);
+  }
+
+  var platform = TriggerReactorCore.getInstance().getPlatform();
+  if (platform.supports(Dependency.MiniMessage)) {
+    var mm = Java.type('net.kyori.adventure.text.minimessage.MiniMessage').miniMessage();
+    message = mm.deserialize(message);
   }
 
   player.sendMessage(message);

--- a/bukkit/src/main/resources/Executor/MESSAGE.js
+++ b/bukkit/src/main/resources/Executor/MESSAGE.js
@@ -45,7 +45,7 @@ function MESSAGE(args) {
     message = PlaceholderAPI.setPlaceholders(player, message);
   }
 
-  var platform = TriggerReactorCore.getInstance().getPlatform();
+  var platform = plugin.getPlatform();
   if (platform.supports(Dependency.MiniMessage)) {
     var mm = Java.type('net.kyori.adventure.text.minimessage.MiniMessage').miniMessage();
     message = mm.deserialize(message);

--- a/bukkit/src/test/java/js/executor/AbstractTestExecutors.java
+++ b/bukkit/src/test/java/js/executor/AbstractTestExecutors.java
@@ -2,6 +2,7 @@ package js.executor;
 
 import io.github.wysohn.triggerreactor.bukkit.main.BukkitTriggerReactorCore;
 import io.github.wysohn.triggerreactor.core.bridge.IInventory;
+import io.github.wysohn.triggerreactor.core.main.Platform;
 import io.github.wysohn.triggerreactor.core.manager.trigger.inventory.InventoryTriggerManager;
 import io.github.wysohn.triggerreactor.core.script.validation.ValidationException;
 import js.AbstractTestJavaScripts;
@@ -733,11 +734,16 @@ public abstract class AbstractTestExecutors extends AbstractTestJavaScripts {
             }
         }
 
+        final BukkitTriggerReactorCore plugin = mock(BukkitTriggerReactorCore.class);
         Player player = mock(Player.class);
         ExampleObject exampleObject = new ExampleObject("Message");
 
+        when(plugin.getPlatform()).thenReturn(Platform.Unknown);
+        // when(Platform.Unknown.supports(eq(Dependency.MiniMessage))).thenReturn(false);
+
         JsTest test = new ExecutorTest(engine, "MESSAGE")
-                .addVariable("player", player);
+                .addVariable("player", player)
+                .addVariable("plugin", plugin);
 
         test.withArgs(exampleObject).test();
 

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/main/Dependency.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/main/Dependency.java
@@ -1,0 +1,41 @@
+package io.github.wysohn.triggerreactor.core.main;
+
+import static io.github.wysohn.triggerreactor.core.util.ClassUtils.classExists;
+
+public enum Dependency {
+
+    Adventure("net.kyori.adventure.Adventure", Platform.Paper),
+    MiniMessage("net.kyori.adventure.text.minimessage.MiniMessage", Platform.Paper);
+
+    private final boolean classExists;
+    private final Platform[] nativeSupportPlatforms;
+
+    Dependency(final String classPath, final Platform... nativeSupportPlatforms) {
+        this.classExists = classExists(classPath);
+        this.nativeSupportPlatforms = nativeSupportPlatforms;
+    }
+
+    /**
+     * Returns whether this dependency is supported or not.
+     *
+     * @return {@code true} if this dependency is supported, {@code false} otherwise
+     */
+    public boolean supports() {
+        return this.classExists;
+    }
+
+    /**
+     * Returns whether this dependency is supported by the specified platform.
+     *
+     * @param platform the platform
+     * @return {@code true} if this dependency is supported by the specified platform, {@code false} otherwise
+     */
+    public boolean supportsBy(final Platform platform) {
+        for (final Platform nativePlatform : nativeSupportPlatforms) {
+            return nativePlatform == platform;
+        }
+
+        return false;
+    }
+
+}

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/main/IPluginManagement.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/main/IPluginManagement.java
@@ -34,4 +34,11 @@ public interface IPluginManagement {
      * @param command the command to be executed (without the slash)
      */
     void runCommandAsConsole(String command);
+
+    /**
+     * Gets the current running platform type for the server implementation.
+     *
+     * @return the current platform type
+     */
+    Platform getPlatform();
 }

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/main/Platform.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/main/Platform.java
@@ -1,0 +1,53 @@
+package io.github.wysohn.triggerreactor.core.main;
+
+import static io.github.wysohn.triggerreactor.core.util.ClassUtils.classExists;
+
+public enum Platform {
+
+    CraftBukkit,
+    Spigot,
+    Paper,
+    Sponge,
+    Unknown;
+
+    public boolean isBukkit() {
+        return this == CraftBukkit || this == Spigot || this == Paper;
+    }
+
+    public boolean isSponge() {
+        return this == Sponge;
+    }
+
+    public boolean isKnown() {
+        return this != Unknown;
+    }
+
+    public boolean supports(final Dependency dependency) {
+        return dependency.supportsBy(this) || dependency.supports();
+    }
+
+    private static final Platform CURRENT = getCurrentPlatform();
+    public static Platform current() {
+        return CURRENT;
+    }
+
+    /**
+     * Obtains the current running platform type for the server implementation.
+     *
+     * @return the current running platform type
+     */
+    public static Platform getCurrentPlatform() {
+        if (classExists("org.spongepowered.api.Sponge")) {
+            return Platform.Sponge;
+        } else if (classExists("io.papermc.paper.plugin.loader.PluginLoader") || classExists("com.destroystokyo.paper.utils.PaperPluginLogger")) {
+            return Platform.Paper;
+        } else if (classExists("org.spigotmc.SpigotConfig")) {
+            return Platform.Spigot;
+        } else if (classExists("org.bukkit.craftbukkit.CraftServer") || classExists("org.bukkit.craftbukkit.Main")) {
+            return Platform.CraftBukkit;
+        }
+
+        return Platform.Unknown;
+    }
+
+}

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/main/TriggerReactorCore.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/main/TriggerReactorCore.java
@@ -75,6 +75,7 @@ public abstract class TriggerReactorCore
     protected Map<String, AbstractAPISupport> sharedVars = new HashMap<>();
     private PluginConfigManager pluginConfigManager;
     private GlobalVariableManager globalVariableManager;
+    private Platform platform;
     private boolean debugging = false;
 
     protected TriggerReactorCore() {
@@ -149,9 +150,16 @@ public abstract class TriggerReactorCore
     public GlobalVariableManager getVariableManager() {
         return globalVariableManager;
     }
+
+    @Override
+    public Platform getPlatform() {
+        return platform;
+    }
+
     public void onCoreEnable() {
         pluginConfigManager = new PluginConfigManager(this);
         globalVariableManager = new GlobalVariableManager(this);
+        platform = Platform.getCurrentPlatform();
     }
 
     public void onCoreDisable() {

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/util/ClassUtils.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/util/ClassUtils.java
@@ -1,0 +1,22 @@
+package io.github.wysohn.triggerreactor.core.util;
+
+public final class ClassUtils {
+
+    private ClassUtils() {}
+
+    /**
+     * Tests whether the given class exists or not in the class hierarchy.
+     *
+     * @param className the {@link Class#getCanonicalName() canonical name} of the class
+     * @return {@code true} if the given class exists, {@code false} otherwise
+     */
+    public static boolean classExists(final String className) {
+        try {
+            Class.forName(className);
+            return true;
+        } catch (final ClassNotFoundException ignored) {
+            return false;
+        }
+    }
+
+}


### PR DESCRIPTION
This pull request fully supports hex color on paper and its forks. Notice that it would be not working on CraftBukkit, Spigot due to they do not have [Kyori Adventure](https://docs.advntr.dev/index.html), but there is still a chance to obtain adventure class by some plugins that shaded it, with the same plugin classloader.

This pull request closes #313

![Minecraft server console that shows hex color is fully supported on paper and its forks](https://github.com/TriggerReactor/TriggerReactor/assets/18323202/79f9922e-3c08-4bb0-9f34-dbd9cf4e5b94)

# 🌟 Features

* Supports hex color on Paper or its forks.


# 🧷 Tracking issues

* #313 
