### PR TITLE
build(ci): let the newest one complete if there are multiple running

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,12 @@ on:
     types: [ opened, reopened, synchronize, labeled ]
     paths: ['core/**', 'bukkit/**', 'sponge/**']
 
+# We only ever need one of these running on a single PR.
+# Just let the newest one complete if there are multiple running.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test_graalvm:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
This pull request allows to let GitHub Actions(GHA) would be stopped multiple running workflows when the newest one is created. The strategy reduces duplicated working progress and wasted costs.

Notice that this PR should be merged into `development` too.