### PR TITLE
add internal-ver "this"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,12 @@ on:
     types: [ opened, reopened, synchronize, labeled ]
     paths: ['core/**', 'bukkit/**', 'sponge/**']
 
+# We only ever need one of these running on a single PR.
+# Just let the newest one complete if there are multiple running.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test_graalvm:
     runs-on: ${{ matrix.os }}

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/Trigger.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/Trigger.java
@@ -185,6 +185,7 @@ public abstract class Trigger implements Cloneable, IObservable {
             return false;
         }
 
+        scriptVars.put("this", this);
         scriptVars.put("event", e);
         scriptVars.putAll(triggerDependencyFacade.getExtraVariables(e));
 


### PR DESCRIPTION
this is a little change, user can access trigger object.
It might not be good for security, but its increase users df, i guess

and The above PR may be used for "sync invTrigger vars form previous Task" that we are working on additionally.

`#GUI "invTrigger", true` <- vars sync status