### PR TITLE
Fix/mysql outdated

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ subprojects {
 
     dependencies {
         // https://mvnrepository.com/artifact/mysql/mysql-connector-java
-        api group: 'mysql', name: 'mysql-connector-java', version: '5.1.13'
+        api group: 'mysql', name: 'mysql-connector-java', version: '8.0.33'
         // https://mvnrepository.com/artifact/org.apache.commons/commons-lang3
         api group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0'
 

--- a/bukkit/src/main/java/io/github/wysohn/triggerreactor/bukkit/main/AbstractJavaPlugin.java
+++ b/bukkit/src/main/java/io/github/wysohn/triggerreactor/bukkit/main/AbstractJavaPlugin.java
@@ -23,7 +23,7 @@ import com.google.common.io.ByteArrayDataOutput;
 import com.google.common.io.ByteStreams;
 import com.google.inject.Module;
 import com.google.inject.*;
-import com.mysql.jdbc.jdbc2.optional.MysqlConnectionPoolDataSource;
+import com.mysql.cj.jdbc.MysqlConnectionPoolDataSource;
 import io.github.wysohn.triggerreactor.bukkit.bridge.BukkitCommandSender;
 import io.github.wysohn.triggerreactor.bukkit.bridge.entity.BukkitPlayer;
 import io.github.wysohn.triggerreactor.bukkit.main.serialize.BukkitConfigurationSerializer;
@@ -347,12 +347,9 @@ public abstract class AbstractJavaPlugin extends JavaPlugin {
             ds.setUser(userName);
             ds.setPassword(password);
             ds.setCharacterEncoding("UTF-8");
-            ds.setUseUnicode(true);
             ds.setAutoReconnectForPools(true);
             ds.setAutoReconnect(true);
-            ds.setAutoReconnectForConnectionPools(true);
 
-            ds.setCachePreparedStatements(true);
             ds.setCachePrepStmts(true);
 
             pool = new MiniConnectionPoolManager(ds, 2);
@@ -368,7 +365,7 @@ public abstract class AbstractJavaPlugin extends JavaPlugin {
             try {
                 conn = pool.getConnection();
             } catch (SQLException e) {
-                // e.printStackTrace();
+                e.printStackTrace();
             } finally {
                 if (conn == null)
                     conn = pool.getValidConnection();

--- a/bukkit/src/main/java/io/github/wysohn/triggerreactor/bukkit/main/MysqlSupport.java
+++ b/bukkit/src/main/java/io/github/wysohn/triggerreactor/bukkit/main/MysqlSupport.java
@@ -1,0 +1,124 @@
+package io.github.wysohn.triggerreactor.bukkit.main;
+
+import com.mysql.cj.jdbc.MysqlConnectionPoolDataSource;
+import io.github.wysohn.triggerreactor.tools.mysql.MiniConnectionPoolManager;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.io.*;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+@Singleton
+public class MysqlSupport {
+    private final String KEY = "dbkey";
+    private final String VALUE = "dbval";
+    private final String tablename = "data";
+
+    private String address;
+    private String dbName;
+
+    private MysqlConnectionPoolDataSource ds;
+    private MiniConnectionPoolManager pool;
+
+    @Inject
+    private MysqlSupport() {
+    }
+
+    void connect(String address, String dbName, String userName, String password) throws SQLException {
+        this.address = address;
+        this.dbName = dbName;
+
+        ds = new MysqlConnectionPoolDataSource();
+        ds.setURL("jdbc:mysql://" + address + "/" + dbName);
+        ds.setUser(userName);
+        ds.setPassword(password);
+        ds.setCharacterEncoding("UTF-8");
+        ds.setAutoReconnectForPools(true);
+        ds.setAutoReconnect(true);
+
+        ds.setCachePrepStmts(true);
+
+        pool = new MiniConnectionPoolManager(ds, 2);
+
+        Connection conn = createConnection();
+        initTable(conn);
+        conn.close();
+    }
+
+    private Connection createConnection() {
+        Connection conn = null;
+
+        try {
+            conn = pool.getConnection();
+        } catch (SQLException e) {
+//            e.printStackTrace();
+        } finally {
+            if (conn == null)
+                conn = pool.getValidConnection();
+        }
+
+        return conn;
+    }
+
+    private final String CREATETABLEQUARY = "" + "CREATE TABLE IF NOT EXISTS %s (" + "" + KEY
+            + " CHAR(128) PRIMARY KEY," + "" + VALUE + " MEDIUMBLOB" + ")";
+
+    private void initTable(Connection conn) throws SQLException {
+        PreparedStatement pstmt = conn.prepareStatement(String.format(CREATETABLEQUARY, tablename));
+        pstmt.executeUpdate();
+        pstmt.close();
+    }
+
+    public Object get(String key) throws SQLException {
+        Object out = null;
+
+        try (Connection conn = createConnection();
+             PreparedStatement pstmt = conn.prepareStatement(
+                     "SELECT " + VALUE + " FROM " + tablename + " WHERE " + KEY + " = ?")) {
+            pstmt.setString(1, key);
+            ResultSet rs = pstmt.executeQuery();
+
+            if (!rs.next())
+                return null;
+            InputStream is = rs.getBinaryStream(VALUE);
+
+            try (ObjectInputStream ois = new ObjectInputStream(is)) {
+                out = ois.readObject();
+            } catch (IOException | ClassNotFoundException e1) {
+                e1.printStackTrace();
+                return null;
+            }
+        }
+
+        return out;
+    }
+
+    public void set(String key, Serializable value) throws SQLException {
+        try (Connection conn = createConnection();
+             PreparedStatement pstmt = conn.prepareStatement("REPLACE INTO " + tablename + " VALUES (?, ?)")) {
+
+
+            try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                 ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+                oos.writeObject(value);
+
+                ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+
+                pstmt.setString(1, key);
+                pstmt.setBinaryStream(2, bais);
+
+                pstmt.executeUpdate();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "Mysql Connection(" + address + ") to [dbName=" + dbName + ", tablename=" + tablename + "]";
+    }
+}

--- a/bukkit/src/main/java/io/github/wysohn/triggerreactor/bukkit/modules/BukkitDriverModule.java
+++ b/bukkit/src/main/java/io/github/wysohn/triggerreactor/bukkit/modules/BukkitDriverModule.java
@@ -36,5 +36,7 @@ public class BukkitDriverModule extends AbstractModule {
         bind(IInventoryHandle.class).to(BukkitInventoryHandle.class);
         bind(IPluginManagement.class).to(BukkitPluginManagement.class);
         bind(TaskSupervisor.class).to(BukkitTaskSupervisor.class);
+
+        bind(MysqlSupport.class);
     }
 }

--- a/bukkit/src/main/resources/Executor/MYSQL.js
+++ b/bukkit/src/main/resources/Executor/MYSQL.js
@@ -17,6 +17,7 @@
  *******************************************************************************/
 
 var Object = Java.type('java.lang.Object');
+var MysqlSupport = Java.type('io.github.wysohn.triggerreactor.bukkit.main.MysqlSupport');
 
 var validation = {
   overloads: [
@@ -28,7 +29,7 @@ var validation = {
 };
 
 function MYSQL(args) {
-  var mysqlHelper = plugin.getMysqlHelper();
+  var mysqlHelper = injector.getInstance(MysqlSupport.class);
 
   if (!mysqlHelper) throw new Error('Mysql connection is not available.');
 

--- a/bukkit/src/main/resources/Placeholder/mysql.js
+++ b/bukkit/src/main/resources/Placeholder/mysql.js
@@ -16,6 +16,8 @@
  *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *******************************************************************************/
 
+var MysqlSupport = Java.type('io.github.wysohn.triggerreactor.bukkit.main.MysqlSupport');
+
 var validation = {
   overloads: [
     [
@@ -25,11 +27,14 @@ var validation = {
 }
 
 function mysql(args) {
-  var key = args[0];
+  var mysqlHelper = injector.getInstance(MysqlSupport.class);
 
-  var mysqlHelper = plugin.getMysqlHelper();
   if (!mysqlHelper)
     throw new Error('Mysql connection is not available. Check your config.yml');
 
-  return mysqlHelper.get(key);
+  if(overload === 0){
+    return mysqlHelper.get(args[0])
+  } else {
+    throw new Error('Missing key');
+  }
 }

--- a/bukkit/src/test/java/js/executor/AbstractTestExecutors.java
+++ b/bukkit/src/test/java/js/executor/AbstractTestExecutors.java
@@ -884,6 +884,7 @@ public abstract class AbstractTestExecutors extends AbstractTestJavaScripts {
 
     @Test
     public void testMysql() throws Exception {
+        // arrange
         class FakeMysqlHelper {
             public void set(String key, Object value) {
             }
@@ -897,17 +898,22 @@ public abstract class AbstractTestExecutors extends AbstractTestJavaScripts {
 
         FakeMysqlHelper mysqlHelper = mock(FakeMysqlHelper.class);
         FakePlugin plugin = mock(FakePlugin.class);
+        Injector injector = mock(Injector.class);
 
         String key = "testKey";
         Object value = 100D;
 
         when(plugin.getMysqlHelper()).thenReturn(mysqlHelper);
+        when(injector.getInstance(any(Class.class))).thenReturn(mysqlHelper);
 
         JsTest test = new ExecutorTest(engine, "MYSQL")
+                .addVariable("injector", injector)
                 .addVariable("plugin", plugin);
 
+        // act
         test.withArgs(key, value).test();
 
+        // assert
         verify(mysqlHelper).set(key, value);
 
         Assert.assertEquals(0, test.getOverload(key, value));

--- a/bukkit/src/test/java/js/placeholder/AbstractTestPlaceholder.java
+++ b/bukkit/src/test/java/js/placeholder/AbstractTestPlaceholder.java
@@ -17,6 +17,7 @@
 
 package js.placeholder;
 
+import com.google.inject.Injector;
 import js.AbstractTestJavaScripts;
 import js.JsTest;
 import js.PlaceholderTest;
@@ -43,6 +44,7 @@ import org.junit.Test;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -920,6 +922,7 @@ public abstract class AbstractTestPlaceholder extends AbstractTestJavaScripts {
 
         FakeMysqlHelper mysqlHelper = mock(FakeMysqlHelper.class);
         FakePlugin plugin = mock(FakePlugin.class);
+        Injector injector = mock(Injector.class);
         Player player = mock(Player.class);
 
         String key = "testKey";
@@ -927,8 +930,10 @@ public abstract class AbstractTestPlaceholder extends AbstractTestJavaScripts {
 
         when(plugin.getMysqlHelper()).thenReturn(mysqlHelper);
         when(mysqlHelper.get(key)).thenReturn(value);
+        when(injector.getInstance(any(Class.class))).thenReturn(mysqlHelper);
 
         JsTest test = new PlaceholderTest(engine, "mysql")
+                .addVariable("injector", injector)
                 .addVariable("player", player)
                 .addVariable("plugin", plugin);
 


### PR DESCRIPTION
- Drops Mysql 5.7 support

It's been 5 years since Mysql 8 was released, and now we have Mysql 8.2. There is no point supporting the version that is no longer supported
![image](https://github.com/TriggerReactor/TriggerReactor/assets/8789836/3b68275c-7d72-444e-8527-f32a813a0601)

- Fix #MYSQL and $mysql accordingly
<!-- bot: paperclip-pr-build -->
---
Download the jar for this pull request: [TriggerReactor-620.zip](https://nightly.link/TriggerReactor/TriggerReactor/actions/artifacts/1015174297.zip)